### PR TITLE
skills(devops): improve discoverability + token economy in 7 skills

### DIFF
--- a/devops-skills-plugin/skills/bash-script-validator/SKILL.md
+++ b/devops-skills-plugin/skills/bash-script-validator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bash-script-validator
-description: Validate, lint, audit, or fix bash/shell/.sh scripts via ShellCheck.
+description: Validate, lint, audit, or fix bash/shell/.sh scripts via ShellCheck. Use when the user asks to lint a .sh file, debug a ShellCheck warning, enforce POSIX portability, or gate scripts before CI. Triggers — "lint this .sh", "why does this script fail shellcheck", "is my bash POSIX-compliant", "review shell script before merge", "fix shellcheck warnings". Not for linting Python/Node/etc. — see language-specific skills.
 ---
 
 # Bash Script Validator
@@ -35,6 +35,8 @@ Use this skill when the request includes script quality, linting, syntax checkin
 - Pure prose editing tasks
 
 ## Deterministic Execution Model
+
+Prerequisites: bash; optional shellcheck (system or wrapper); optional python3 (for the wrapper provider).
 
 Run commands from this skill directory:
 
@@ -89,7 +91,11 @@ For each issue, include:
 
 If the request includes patching files and write access is available, apply fixes in small batches grouped by issue type.
 
-### Step 5: Rerun Policy (Mandatory After Changes)
+Before any in-place edit, show a unified diff of the proposed changes and ask the user: `Apply these N fixes to <file>?` Only proceed after explicit confirmation.
+
+Rollback: if a rerun shows the script is broken, revert with `git checkout -- <file>` or restore from a pre-fix snapshot of the script.
+
+### Step 5: Rerun Policy
 
 After each batch of edits, rerun the validator:
 
@@ -102,7 +108,7 @@ Rerun loop rules:
 1. Continue until no new errors are introduced.
 2. If warnings remain by design, document why they are intentionally accepted.
 3. If constraints prevent full resolution, report unresolved items with a clear next action.
-4. Always report the latest rerun exit code and remaining issue count.
+4. Report the latest rerun exit code and remaining issue count (why: lets the caller verify the loop terminated cleanly).
 
 ## Fallback Behavior
 
@@ -121,7 +127,7 @@ Use these branches only when the default flow cannot run as-is.
 
 Use subsection-level citations for every non-trivial fix.
 
-Required citation format:
+Citation format (why: lets reviewers verify the rationale without re-reading the full reference):
 
 ```text
 Reference: docs/<file>.md -> <Section> -> <Subsection>
@@ -233,14 +239,3 @@ Load only what is needed:
 - `docs/awk-reference.md`
 - `docs/sed-reference.md`
 - `docs/regex-reference.md`
-
-## Done Criteria
-
-This skill update is complete when all are true:
-
-1. Trigger guidance is explicit (positive and non-trigger examples).
-2. Default workflow is deterministic and ordered.
-3. Fallback behavior is explicit for missing tooling and constrained environments.
-4. Fix explanations include subsection-level citations.
-5. Post-fix rerun policy is mandatory and reported with exit codes.
-6. Documentation supports both fully automated and constrained execution paths.

--- a/devops-skills-plugin/skills/bash-script-validator/docs/awk-reference.md
+++ b/devops-skills-plugin/skills/bash-script-validator/docs/awk-reference.md
@@ -1,5 +1,22 @@
 # GNU AWK (gawk) Reference Guide
 
+## Contents
+
+- [Overview](#overview)
+- [Basic Syntax](#basic-syntax)
+- [Structure](#structure)
+- [Built-in Variables](#built-in-variables)
+- [Common Usage Patterns](#common-usage-patterns)
+- [Arrays](#arrays)
+- [Functions](#functions)
+- [Practical Examples for Shell Scripts](#practical-examples-for-shell-scripts)
+- [Multi-line AWK Scripts](#multi-line-awk-scripts)
+- [Common Patterns](#common-patterns)
+- [Performance Tips](#performance-tips)
+- [Common Pitfalls in Shell Scripts](#common-pitfalls-in-shell-scripts)
+- [Combining with Other Tools](#combining-with-other-tools)
+- [Resources](#resources)
+
 ## Overview
 
 AWK is a powerful text processing language designed for pattern scanning and processing. It's particularly useful for field-based data manipulation.

--- a/devops-skills-plugin/skills/bash-script-validator/docs/bash-reference.md
+++ b/devops-skills-plugin/skills/bash-script-validator/docs/bash-reference.md
@@ -1,5 +1,16 @@
 # Bash Reference Guide
 
+## Contents
+
+- [Overview](#overview)
+- [Bash vs POSIX Shell (sh)](#bash-vs-posix-shell-sh)
+- [Core Bash Syntax](#core-bash-syntax)
+- [Best Practices](#best-practices)
+- [Common Pitfalls](#common-pitfalls)
+- [Parameter Expansion Reference](#parameter-expansion-reference)
+- [Special Variables](#special-variables)
+- [Resources](#resources)
+
 ## Overview
 
 Bash (Bourne Again SHell) is a Unix shell and command language. This guide covers bash-specific features, syntax, and best practices.

--- a/devops-skills-plugin/skills/bash-script-validator/docs/common-mistakes.md
+++ b/devops-skills-plugin/skills/bash-script-validator/docs/common-mistakes.md
@@ -2,6 +2,36 @@
 
 This guide covers frequent mistakes made in bash and shell scripts, their consequences, and how to fix them.
 
+## Contents
+
+- [1. Unquoted Variables](#1-unquoted-variables)
+- [2. Not Checking Command Success](#2-not-checking-command-success)
+- [3. Using [ ] with Bash Features](#3-using---with-bash-features)
+- [4. Useless Use of cat (UUOC)](#4-useless-use-of-cat-uuoc)
+- [5. Not Using -r with read](#5-not-using--r-with-read)
+- [6. Testing $? After Multiple Commands](#6-testing--after-multiple-commands)
+- [7. Arrays in POSIX sh Scripts](#7-arrays-in-posix-sh-scripts)
+- [8. Not Declaring Functions Before Use](#8-not-declaring-functions-before-use)
+- [9. Using eval Unsafely](#9-using-eval-unsafely)
+- [10. Forgetting set -u](#10-forgetting-set--u)
+- [11. Incorrect String Comparison](#11-incorrect-string-comparison)
+- [12. Not Handling Spaces in Filenames](#12-not-handling-spaces-in-filenames)
+- [13. Backticks Instead of $()](#13-backticks-instead-of-)
+- [14. Using = Instead of == in [[ ]]](#14-using--instead-of--in--)
+- [15. Not Quoting $@](#15-not-quoting-)
+- [16. Using ls to Process Files](#16-using-ls-to-process-files)
+- [17. Incorrect Exit Codes](#17-incorrect-exit-codes)
+- [18. Using -a and -o in [ ]](#18-using--a-and--o-in--)
+- [19. Not Making Scripts Executable](#19-not-making-scripts-executable)
+- [20. Forgetting Final Newline](#20-forgetting-final-newline)
+- [21. Using grep -q Without Knowing Implications](#21-using-grep--q-without-knowing-implications)
+- [22. Incorrect glob Pattern](#22-incorrect-glob-pattern)
+- [23. Not Handling Empty Globs](#23-not-handling-empty-globs)
+- [24. Not Sanitizing Input](#24-not-sanitizing-input)
+- [25. Using -e for File Existence](#25-using--e-for-file-existence)
+- [Quick Checklist](#quick-checklist)
+- [Resources](#resources)
+
 ## 1. Unquoted Variables
 
 ### Problem

--- a/devops-skills-plugin/skills/bash-script-validator/docs/grep-reference.md
+++ b/devops-skills-plugin/skills/bash-script-validator/docs/grep-reference.md
@@ -1,5 +1,20 @@
 # GNU grep Reference Guide
 
+## Contents
+
+- [Overview](#overview)
+- [Basic Syntax](#basic-syntax)
+- [Common Options](#common-options)
+- [Common Usage Patterns](#common-usage-patterns)
+- [Regular Expressions in grep](#regular-expressions-in-grep)
+- [Character Classes](#character-classes)
+- [Practical Examples for Shell Scripts](#practical-examples-for-shell-scripts)
+- [Performance Tips](#performance-tips)
+- [Exit Codes](#exit-codes)
+- [Common Pitfalls in Shell Scripts](#common-pitfalls-in-shell-scripts)
+- [Useful Combinations](#useful-combinations)
+- [Resources](#resources)
+
 ## Overview
 
 grep (Global Regular Expression Print) searches for patterns in text files. It's one of the most commonly used Unix tools.

--- a/devops-skills-plugin/skills/bash-script-validator/docs/regex-reference.md
+++ b/devops-skills-plugin/skills/bash-script-validator/docs/regex-reference.md
@@ -1,5 +1,23 @@
 # Regular Expressions Reference Guide
 
+## Contents
+
+- [Overview](#overview)
+- [BRE vs ERE](#bre-vs-ere)
+- [Basic Metacharacters (Both BRE and ERE)](#basic-metacharacters-both-bre-and-ere)
+- [Extended Metacharacters](#extended-metacharacters)
+- [POSIX Character Classes](#posix-character-classes)
+- [Common Patterns](#common-patterns)
+- [Shell Script Patterns](#shell-script-patterns)
+- [Escaping Special Characters](#escaping-special-characters)
+- [Backreferences](#backreferences)
+- [Greedy vs Non-Greedy](#greedy-vs-non-greedy)
+- [Lookahead and Lookbehind](#lookahead-and-lookbehind)
+- [Common Mistakes](#common-mistakes)
+- [Testing Regex](#testing-regex)
+- [Quick Reference Table](#quick-reference-table)
+- [Resources](#resources)
+
 ## Overview
 
 Regular expressions (regex) are patterns used to match character combinations in strings. POSIX defines two flavors: Basic (BRE) and Extended (ERE).

--- a/devops-skills-plugin/skills/bash-script-validator/docs/sed-reference.md
+++ b/devops-skills-plugin/skills/bash-script-validator/docs/sed-reference.md
@@ -1,5 +1,24 @@
 # GNU sed Reference Guide
 
+## Contents
+
+- [Overview](#overview)
+- [Basic Syntax](#basic-syntax)
+- [Common Options](#common-options)
+- [Basic Commands](#basic-commands)
+- [Address Ranges](#address-ranges)
+- [Advanced Substitution](#advanced-substitution)
+- [Multiple Commands](#multiple-commands)
+- [In-place Editing](#in-place-editing)
+- [Pattern Matching](#pattern-matching)
+- [Practical Examples for Shell Scripts](#practical-examples-for-shell-scripts)
+- [Advanced Features](#advanced-features)
+- [Common Patterns](#common-patterns)
+- [Common Pitfalls in Shell Scripts](#common-pitfalls-in-shell-scripts)
+- [Performance Tips](#performance-tips)
+- [Testing sed Commands](#testing-sed-commands)
+- [Resources](#resources)
+
 ## Overview
 
 sed (Stream EDitor) is a powerful text processing tool that performs basic text transformations on an input stream (file or pipeline).

--- a/devops-skills-plugin/skills/bash-script-validator/docs/shell-reference.md
+++ b/devops-skills-plugin/skills/bash-script-validator/docs/shell-reference.md
@@ -1,5 +1,19 @@
 # POSIX Shell (sh) Reference Guide
 
+## Contents
+
+- [Overview](#overview)
+- [Why POSIX Shell Matters](#why-posix-shell-matters)
+- [Key Differences: sh vs bash](#key-differences-sh-vs-bash)
+- [POSIX Shell Syntax](#posix-shell-syntax)
+- [POSIX Best Practices](#posix-best-practices)
+- [Common Portability Issues](#common-portability-issues)
+- [POSIX Parameter Expansion](#posix-parameter-expansion)
+- [Special Variables (POSIX)](#special-variables-posix)
+- [Testing for POSIX Compliance](#testing-for-posix-compliance)
+- [Common POSIX Utilities](#common-posix-utilities)
+- [Resources](#resources)
+
 ## Overview
 
 POSIX sh is the portable shell specification defined by POSIX standards. Scripts written for POSIX sh should work across different Unix-like systems (bash, dash, ksh, etc.).

--- a/devops-skills-plugin/skills/bash-script-validator/docs/shellcheck-reference.md
+++ b/devops-skills-plugin/skills/bash-script-validator/docs/shellcheck-reference.md
@@ -1,5 +1,23 @@
 # ShellCheck Reference Guide
 
+## Contents
+
+- [Overview](#overview)
+- [Installation](#installation)
+- [Basic Usage](#basic-usage)
+- [Severity Levels](#severity-levels)
+- [Common Error Codes](#common-error-codes)
+- [Disabling Checks](#disabling-checks)
+- [ShellCheck Directives](#shellcheck-directives)
+- [Configuration File](#configuration-file)
+- [Integration with CI/CD](#integration-with-cicd)
+- [Common Patterns and Best Practices](#common-patterns-and-best-practices)
+- [Advanced Features](#advanced-features)
+- [Exit Codes](#exit-codes)
+- [Editor Integration](#editor-integration)
+- [Resources](#resources)
+- [Quick Reference Table](#quick-reference-table)
+
 ## Overview
 
 ShellCheck is a static analysis tool for shell scripts that provides warnings and suggestions for syntax and semantic issues to improve script quality and prevent errors.

--- a/devops-skills-plugin/skills/dockerfile-validator/SKILL.md
+++ b/devops-skills-plugin/skills/dockerfile-validator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dockerfile-validator
-description: Validate, lint, audit, or scan a Dockerfile for security and best practices.
+description: Use when validating, linting, scanning, or hardening an existing Dockerfile for security, best practices, or image-size/build-time issues. Triggers "lint Dockerfile", "scan Dockerfile for vulnerabilities", "review Dockerfile.prod", "Dockerfile security check", "optimize image size/build". Not for authoring a new Dockerfile from scratch — see dockerfile-generator.
 ---
 
 # Dockerfile Validator
@@ -20,7 +20,7 @@ Use this skill when the user asks for tasks like:
 ## Use / Do Not Use
 
 Use this skill for:
-- Syntax and lint validation
+- Syntax and validation
 - Security and secrets checks
 - Best-practice and performance review
 - Dockerfile hardening before CI/CD or production
@@ -29,16 +29,17 @@ Do not use this skill for:
 - Generating a new Dockerfile from scratch (use `dockerfile-generator`)
 - Running containers, debugging runtime behavior, or image registry operations
 
-## Local Files In This Skill
+## Skill Contents
 
 - Validator script: `scripts/dockerfile-validate.sh`
+- CI/regression entrypoint: `scripts/test_validate.sh`
 - References:
-  - `references/security_checklist.md`
-  - `references/optimization_guide.md`
-  - `references/docker_best_practices.md`
-- Example Dockerfiles: `examples/*.Dockerfile`
+  - `references/security_checklist.md` — secrets, root user, hardening, registry/runtime
+  - `references/optimization_guide.md` — image size, layer count, multi-stage, cache, `.dockerignore`
+  - `references/docker_best_practices.md` — instruction usage, tag pinning, COPY vs ADD, conventions
+- Examples: `examples/good-example.Dockerfile`, `examples/bad-example.Dockerfile`, `examples/security-issues.Dockerfile`, `examples/python-optimized.Dockerfile`, `examples/golang-distroless.Dockerfile`
 
-## Deterministic Execution Flow (Required)
+## Deterministic Execution Flow
 
 Run these steps in order. Do not skip steps unless a documented fallback branch applies.
 
@@ -61,19 +62,9 @@ test -f "$TARGET_DOCKERFILE"
 
 If either check fails, stop and report the exact missing path.
 
-### 2. Read the Target Dockerfile Explicitly
+### 2. Read the Target Dockerfile
 
-Use explicit file-read commands (not abstract "Read tool" wording):
-
-```bash
-sed -n '1,220p' "$TARGET_DOCKERFILE"
-```
-
-If needed for long files:
-
-```bash
-sed -n '220,440p' "$TARGET_DOCKERFILE"
-```
+Use the Read tool on `$TARGET_DOCKERFILE` to load its contents into context before running the validator. For very long files, page through with the Read tool's `offset`/`limit` parameters.
 
 ### 3. Run Validation Script
 
@@ -83,15 +74,11 @@ Primary command:
 bash "$SKILL_DIR/scripts/dockerfile-validate.sh" "$TARGET_DOCKERFILE"
 ```
 
-Optional captured run for structured reporting:
+The script's stdout is captured directly in the conversation context — no `tee` redirect is required.
 
-```bash
-bash "$SKILL_DIR/scripts/dockerfile-validate.sh" "$TARGET_DOCKERFILE" | tee /tmp/dockerfile-validator.out
-```
+### 4. Classify Findings by Severity
 
-### 4. Classify Findings by Severity (Standard)
-
-Use this standard severity model:
+Use this severity model:
 
 - `Critical`
   - Hardcoded secrets/credentials
@@ -107,12 +94,12 @@ Use this standard severity model:
 - `Low`
   - Style/info guidance and non-blocking optimization suggestions
 
-### 5. No-Issue Fast Path (Required)
+### 5. No-Issue Fast Path
 
 If validation has no actionable findings:
 - Return a concise pass summary.
-- Do **not** open reference files.
-- Do **not** generate fix diffs.
+- Do not open reference files.
+- Do not generate fix diffs.
 
 Use fast path when all are true:
 - Script reports overall pass.
@@ -131,15 +118,9 @@ Issue-to-reference mapping:
 | Image size, layer count, multi-stage opportunities, cache efficiency, `.dockerignore` gaps | too many `RUN`, single-stage with build deps, cache misses | `references/optimization_guide.md` |
 | Tag pinning, instruction usage, COPY vs ADD, WORKDIR/CMD/ENTRYPOINT conventions | `:latest`, unpinned packages, instruction-level best practices | `references/docker_best_practices.md` |
 
-Explicit read commands:
+Use the Read tool on the matching reference file(s). Each reference has a section index at the top — jump to the relevant section rather than reading end-to-end.
 
-```bash
-sed -n '1,220p' "$SKILL_DIR/references/security_checklist.md"
-sed -n '1,220p' "$SKILL_DIR/references/optimization_guide.md"
-sed -n '1,220p' "$SKILL_DIR/references/docker_best_practices.md"
-```
-
-For targeted extraction:
+For targeted extraction within a reference:
 
 ```bash
 rg -n "USER|secrets|EXPOSE|HEALTHCHECK" "$SKILL_DIR/references/security_checklist.md"
@@ -185,7 +166,21 @@ After reporting:
 - Ask whether to apply fixes.
 - If user approves, patch the Dockerfile and rerun validation.
 
-## Fallback Behavior (Explicit)
+## Recovery
+
+When applied fixes break the build (`docker build` fails after the patch, or a rerun introduces new errors), undo the changes before iterating:
+
+```bash
+# If the Dockerfile is tracked and unstaged
+git checkout -- Dockerfile
+
+# If you want to keep the attempt for inspection
+git stash push -m "dockerfile-validator failed fix" -- Dockerfile
+```
+
+Then rerun the validator on the restored file and propose a smaller patch.
+
+## Fallback Behavior
 
 When the primary script cannot complete, use deterministic fallback branches and report them.
 
@@ -224,43 +219,6 @@ docker run --rm -i hadolint/hadolint < "$TARGET_DOCKERFILE"
 
 Run only manual regex-based checks (Fallback A step 2), clearly mark as `PARTIAL`, and state which scanners were skipped.
 
-## Quick Command Set
-
-### Validate one Dockerfile
-
-```bash
-cd /path/to/repo
-bash devops-skills-plugin/skills/dockerfile-validator/scripts/dockerfile-validate.sh Dockerfile
-```
-
-### Validate alternate file
-
-```bash
-cd /path/to/repo
-bash devops-skills-plugin/skills/dockerfile-validator/scripts/dockerfile-validate.sh Dockerfile.prod
-```
-
-### Validate skill examples
-
-```bash
-cd /path/to/repo/devops-skills-plugin/skills/dockerfile-validator
-bash scripts/dockerfile-validate.sh examples/good-example.Dockerfile
-bash scripts/dockerfile-validate.sh examples/security-issues.Dockerfile
-```
-
-### Run regression checks (CI entrypoint)
-
-```bash
-cd /path/to/repo
-bash devops-skills-plugin/skills/dockerfile-validator/scripts/test_validate.sh
-```
-
-Optional strict mode for CI environments that must enforce ShellCheck:
-
-```bash
-STRICT_SHELLCHECK=true bash devops-skills-plugin/skills/dockerfile-validator/scripts/test_validate.sh
-```
-
 ## Progressive Disclosure Rules
 
 - Always read the target Dockerfile first.
@@ -272,22 +230,13 @@ STRICT_SHELLCHECK=true bash devops-skills-plugin/skills/dockerfile-validator/scr
 
 Consider this skill execution complete only when all conditions below are satisfied:
 
-- Trigger matched a Dockerfile validation/lint/security/optimization request.
+- Trigger matched a Dockerfile validation request.
 - Target Dockerfile path was explicitly verified.
 - Validation command (or explicit fallback) was executed.
 - Findings were reported using severity buckets (`Critical`, `High`, `Medium`, `Low`).
 - Reference usage matched issue categories and was explicitly listed.
 - No-issue fast path skipped unnecessary reference reads.
 - If fixes were applied, validation was rerun and final status reported.
-
-## Resources
-
-- Script: `scripts/dockerfile-validate.sh`
-- CI/regression entrypoint: `scripts/test_validate.sh`
-- Security reference: `references/security_checklist.md`
-- Optimization reference: `references/optimization_guide.md`
-- Best-practices reference: `references/docker_best_practices.md`
-- Examples: `examples/good-example.Dockerfile`, `examples/bad-example.Dockerfile`, `examples/security-issues.Dockerfile`, `examples/python-optimized.Dockerfile`, `examples/golang-distroless.Dockerfile`
 
 ## Source Links
 

--- a/devops-skills-plugin/skills/dockerfile-validator/references/docker_best_practices.md
+++ b/devops-skills-plugin/skills/dockerfile-validator/references/docker_best_practices.md
@@ -2,6 +2,15 @@
 
 This document summarizes official Docker best practices based on current recommendations from Docker documentation and industry standards.
 
+## Contents
+
+- [General Principles](#general-principles) — ephemeral containers, build context, multi-stage, single concern
+- [Dockerfile Instructions Best Practices](#dockerfile-instructions-best-practices) — FROM, RUN, COPY/ADD, WORKDIR, USER, CMD/ENTRYPOINT
+- [Build Optimization](#build-optimization) — instruction order, BuildKit cache and secret mounts
+- [Security Best Practices](#security-best-practices) — non-root user, secrets, minimal surface
+- [Common Anti-Patterns](#common-anti-patterns) — missing cleanup, bloated layers
+- [Resources](#resources)
+
 ## General Principles
 
 ### 1. Create Ephemeral Containers

--- a/devops-skills-plugin/skills/dockerfile-validator/references/optimization_guide.md
+++ b/devops-skills-plugin/skills/dockerfile-validator/references/optimization_guide.md
@@ -2,6 +2,18 @@
 
 Comprehensive guide for optimizing Docker images for size, build time, and runtime performance.
 
+## Contents
+
+- [Image Size Optimization](#image-size-optimization) — base image choice, multi-stage, layer reduction
+- [Build Time Optimization](#build-time-optimization) — instruction order, BuildKit cache mounts, parallel stages
+- [Runtime Performance Optimization](#runtime-performance-optimization) — exec form, CPU/parallelism
+- [Language-Specific Optimizations](#language-specific-optimizations) — Python, Node, Go patterns
+- [Advanced Techniques](#advanced-techniques) — distroless, scratch, BuildKit features
+- [Optimization Checklist](#optimization-checklist)
+- [Measuring Optimization](#measuring-optimization) — `docker images`, build-time comparisons
+- [Tools for Analysis](#tools-for-analysis) — dive, hadolint, container-diff
+- [Resources](#resources)
+
 ## Image Size Optimization
 
 ### 1. Choose Minimal Base Images

--- a/devops-skills-plugin/skills/dockerfile-validator/references/security_checklist.md
+++ b/devops-skills-plugin/skills/dockerfile-validator/references/security_checklist.md
@@ -2,6 +2,18 @@
 
 A comprehensive security checklist for Dockerfiles and container images.
 
+## Contents
+
+- [Build-Time Security](#build-time-security) — base image, secrets, packages, user/permissions, file security
+- [Common Vulnerabilities](#common-vulnerabilities)
+- [Runtime Security](#runtime-security)
+- [Image Registry Security](#image-registry-security)
+- [Security Scanning Tools](#security-scanning-tools)
+- [Compliance and Standards](#compliance-and-standards)
+- [Quick Security Wins](#quick-security-wins)
+- [Security Checklist Summary](#security-checklist-summary)
+- [Resources](#resources)
+
 ## Build-Time Security
 
 ### Base Image Security

--- a/devops-skills-plugin/skills/dockerfile-validator/scripts/dockerfile-validate.sh
+++ b/devops-skills-plugin/skills/dockerfile-validator/scripts/dockerfile-validate.sh
@@ -372,6 +372,7 @@ run_best_practices() {
 
     # Check RUN command efficiency (using normalized content for accurate counting)
     RUN_COUNT=$(count_instruction "$normalized_content" "RUN")
+    # Threshold of 5 follows hadolint DL3059 ("Multiple consecutive RUN instructions") guidance: each RUN adds a layer, so >5 is a strong signal of unmerged commands.
     if [ "$RUN_COUNT" -gt "5" ]; then
         echo -e "${PURPLE}[INFO] High number of RUN commands ($RUN_COUNT)${NC}"
         echo "  → Consider combining related commands to reduce layers"
@@ -551,6 +552,7 @@ run_optimization() {
 
     echo -e "${BLUE}Layer Optimization:${NC}"
     echo "  RUN commands: $RUN_COUNT"
+    # Threshold of 7 is the stricter optimization tier above hadolint DL3059's general RUN-merge recommendation: at this point a single combined RUN almost always reduces image size meaningfully.
     if [ "$RUN_COUNT" -gt "7" ]; then
         echo -e "  ${PURPLE}[OPTIMIZATION] Consider combining RUN commands${NC}"
         echo "    → Reduces layer count and image size"

--- a/devops-skills-plugin/skills/github-actions-generator/SKILL.md
+++ b/devops-skills-plugin/skills/github-actions-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-actions-generator
-description: Create, generate, or scaffold GitHub Actions workflows, action.yml, or .github/workflows CI/CD pipelines.
+description: Use when creating, generating, or scaffolding GitHub Actions workflows (.github/workflows/*.yml), composite/Docker/JavaScript actions (action.yml), reusable workflows, or CI/CD pipelines for GitHub. Triggers — 'set up CI', 'add GitHub Action', 'build a workflow', 'create a custom action', 'make this reusable'. Not for Jenkins/GitLab/CircleCI; for editing existing workflows or validation, see devops-skills:github-actions-validator.
 ---
 
 # GitHub Actions Generator
@@ -156,8 +156,8 @@ See `references/advanced-triggers.md` for complete patterns.
 **Triggers:** "Add security scanning...", "Add dependency review...", "Generate SBOM..."
 
 **Components:**
-- **Dependency Review:** `actions/dependency-review-action@v4`
-- **SBOM Attestations:** `actions/attest-sbom@v2`
+- **Dependency Review:** `actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3`
+- **SBOM Attestations:** `actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2.4.0`
 - **CodeQL Analysis:** `github/codeql-action`
 
 **Permission Model:**
@@ -197,8 +197,8 @@ When using third-party actions (any `uses:` entry not in the same repository):
    ```
 
 2. **Or use Context7 MCP:**
-   - `mcp__context7__resolve-library-id` to find action
-   - `mcp__context7__query-docs` for documentation
+   - `Context7:resolve-library-id` to find action
+   - `Context7:query-docs` for documentation
 
 3. **Pin to SHA with version comment:**
    ```yaml
@@ -217,12 +217,13 @@ See `references/common-actions.md` for pre-verified action versions.
 
 ## Validation Workflow
 
-**CRITICAL:** Every generated resource MUST be validated.
+Validate every generated resource before presenting it.
 
 1. Generate workflow/action file
 2. Invoke `devops-skills:github-actions-validator` skill
 3. If errors: fix and re-validate
 4. If success: present with usage instructions
+5. **Run** `bash scripts/test_generator.sh` after edits to this skill's templates or generator logic.
 
 **Skip validation only for:**
 - Partial code snippets
@@ -248,9 +249,9 @@ Fallback usage must always be reported in the final output.
 
 ---
 
-## Mandatory Standards
+## Generation Standards
 
-All generated resources must follow:
+Apply the following to every generated resource:
 
 | Standard | Implementation |
 |----------|---------------|

--- a/devops-skills-plugin/skills/github-actions-generator/references/best-practices.md
+++ b/devops-skills-plugin/skills/github-actions-generator/references/best-practices.md
@@ -1,8 +1,5 @@
 # GitHub Actions Best Practices
 
-**Last Updated:** November 2025
-**Based on:** Official GitHub Actions documentation and Context7 verified sources
-
 ## Table of Contents
 1. [Security Best Practices](#security-best-practices)
 2. [Performance Optimization](#performance-optimization)
@@ -753,3 +750,12 @@ jobs:
 5. Follow conventions: Standard naming, proper versioning, community practices
 
 Always validate workflows with the github-actions-validator skill before deploying.
+
+---
+
+## Version notes
+
+Verify against current upstream sources before relying on dated material below.
+
+- Last updated: November 2025
+- Based on: Official GitHub Actions documentation and Context7 verified sources

--- a/devops-skills-plugin/skills/github-actions-generator/references/common-actions.md
+++ b/devops-skills-plugin/skills/github-actions-generator/references/common-actions.md
@@ -1,15 +1,8 @@
 # Common GitHub Actions Reference
 
-**Last Updated:** February 2026
-**Source:** Official GitHub Actions repositories and Context7 verified documentation
-
 This document catalogs frequently used GitHub Actions with current versions, inputs, outputs, and usage examples.
 
-**Important Notes for 2026:**
-- All actions should be pinned to full 40-character SHA for security
-- Node 24 runtime is now supported (Node 20 EOL: April 2026, default switch: March 4, 2026)
-- actions/cache v5.0.3 recommended (Node 24 runtime, runner v2.327.1+)
-- Cache size limits: 10 GB free per repository, additional storage available (as of February 2026)
+All actions should be pinned to full 40-character SHA for security.
 
 ## Table of Contents
 1. [Repository and Checkout](#repository-and-checkout)
@@ -713,3 +706,15 @@ permissions:
 - Verify minimum runner requirements
 
 Always verify action inputs and outputs from official documentation before use.
+
+---
+
+## Version notes
+
+Verify against current upstream sources before relying on dated material below.
+
+- Last updated: February 2026
+- Source: Official GitHub Actions repositories and Context7 verified documentation
+- Node 24 runtime is supported (Node 20 EOL: April 2026, default switch: March 4, 2026)
+- actions/cache v5.0.3 recommended (Node 24 runtime, runner v2.327.1+)
+- Cache size limits: 10 GB free per repository, additional storage available (as of February 2026)

--- a/devops-skills-plugin/skills/helm-generator/SKILL.md
+++ b/devops-skills-plugin/skills/helm-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helm-generator
-description: Create, scaffold, or generate Helm charts, Chart.yaml, values.yaml, templates, helpers.
+description: Use when scaffolding new Helm charts or converting Kubernetes manifests to Helm. Generates Chart.yaml, values.yaml, _helpers.tpl, and resource templates (Deployment/StatefulSet/DaemonSet/Service/Ingress/HPA). Triggers — 'create Helm chart', 'scaffold chart', 'generate Helm templates', 'convert manifests to Helm', 'package as Helm chart'. Not for linting/validating existing charts (use helm-validator) or raw K8s YAML (use k8s-yaml-generator).
 ---
 
 # Helm Chart Generator
@@ -91,6 +91,7 @@ Options:
 - `--with-ingress` - Include ingress template
 - `--with-hpa` - Include HPA template
 - `--force` - Overwrite existing chart without prompting
+- `--dry-run` - Print planned file tree and Chart.yaml/values.yaml previews without writing or removing anything
 
 Image parsing behavior:
 - `--image nginx:1.27` -> repository `nginx`, tag `1.27`
@@ -99,7 +100,7 @@ Image parsing behavior:
 - `--tag` cannot be combined with digest image references
 
 Idempotency and overwrite behavior:
-- `generate_chart_structure.sh`: prompts before overwrite; `--force` overwrites non-interactively.
+- `generate_chart_structure.sh`: prompts before overwrite; `--force` overwrites non-interactively; `--dry-run` previews the plan without writing or removing files.
 - `generate_standard_helpers.sh`: prompts before replacing `templates/_helpers.tpl`; `--force` bypasses prompt.
 
 Expected scaffold shape:
@@ -153,23 +154,7 @@ Resource coverage from `references/resource_templates.md`:
 - Network: NetworkPolicy
 - Autoscaling: HPA, PodDisruptionBudget
 
-Required template patterns:
-```yaml
-metadata:
-  name: {{ include "mychart.fullname" . }}
-  labels: {{- include "mychart.labels" . | nindent 4 }}
-
-{{- with .Values.nodeSelector }}
-nodeSelector: {{- toYaml . | nindent 2 }}
-{{- end }}
-
-annotations:
-  {{- if and .Values.configMap .Values.configMap.enabled }}
-  checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-  {{- end }}
-```
-
-Checksum annotations are required for workloads, but must be conditional and only reference generated templates (`configmap.yaml`, `secret.yaml`).
+Required template patterns: see `references/resource_templates.md` -> "Required Template Patterns".
 
 ### Stage 6: Create values.yaml
 
@@ -184,6 +169,8 @@ Structure guidelines:
 See `assets/values-schema-template.json` for JSON Schema validation.
 
 ### Stage 7: Validate
+
+Prerequisites: Requires helm 3.x; tests additionally require python3.
 
 Preferred path: run the `helm-validator` skill.
 
@@ -202,17 +189,7 @@ Re-run validation after any fixes.
 
 ## Template Functions Quick Reference
 
-See `references/helm_template_functions.md` for complete guide.
-
-| Function | Purpose | Example |
-|----------|---------|---------|
-| `required` | Enforce required values | `{{ required "msg" .Values.x }}` |
-| `default` | Fallback value | `{{ .Values.x \| default 1 }}` |
-| `quote` | Quote strings | `{{ .Values.x \| quote }}` |
-| `include` | Use helpers | `{{ include "name" . \| nindent 4 }}` |
-| `toYaml` | Convert to YAML | `{{ toYaml .Values.x \| nindent 2 }}` |
-| `tpl` | Render as template | `{{ tpl .Values.config . }}` |
-| `nindent` | Newline + indent | `{{- include "x" . \| nindent 4 }}` |
+See `references/helm_template_functions.md` -> "Quick Reference" for the function table and the rest of the guide.
 
 ## Working with CRDs
 
@@ -241,6 +218,15 @@ Key points:
 | Port mismatch (Service vs container) | Set both `service.port` and `service.targetPort`, then re-run `helm template test <chart-dir>` |
 | CRD validation fails | Verify apiVersion/spec fields with Context7 or operator docs, then re-render |
 | Script argument failures | Run `bash scripts/generate_chart_structure.sh --help` and pass required values for option flags |
+
+### Recovery
+
+If you scaffolded over the wrong directory (the script's overwrite path runs `rm -rf "$CHART_DIR"` after `--force` or interactive confirmation):
+
+- If the target was tracked in git: `git status` to see the deletions, then `git restore <paths>` (or `git checkout -- <paths>`) to bring the prior contents back. Untracked files removed by `rm -rf` cannot be recovered with git.
+- If you have a backup (snapshot, IDE local history, filesystem backup), restore from it before re-running the script.
+- Before re-running, use `--dry-run` to confirm the target path and planned tree, then re-run without `--dry-run` once correct.
+- To avoid the failure mode in the future: run `--dry-run` first against any path that may already contain real chart content; never pass `--force` until the dry-run output matches your intent.
 
 ## Example Flows
 

--- a/devops-skills-plugin/skills/helm-generator/references/helm_template_functions.md
+++ b/devops-skills-plugin/skills/helm-generator/references/helm_template_functions.md
@@ -2,6 +2,37 @@
 
 Comprehensive guide to Helm template functions with practical examples.
 
+## Table of Contents
+
+- [Quick Reference](#quick-reference)
+- [Essential Template Functions](#essential-template-functions)
+- [Logical Functions](#logical-functions)
+- [Comparison Functions](#comparison-functions)
+- [String Functions (Sprig)](#string-functions-sprig)
+- [List Functions (Sprig)](#list-functions-sprig)
+- [Dict/Map Functions (Sprig)](#dictmap-functions-sprig)
+- [Type Functions](#type-functions)
+- [Crypto Functions](#crypto-functions)
+- [Date Functions](#date-functions)
+- [Regex Functions](#regex-functions)
+- [Flow Control Functions](#flow-control-functions)
+- [Lookup Function (Cluster Queries)](#lookup-function-cluster-queries)
+- [Best Practices](#best-practices)
+- [Common Patterns](#common-patterns)
+- [Resources](#resources)
+
+## Quick Reference
+
+| Function | Purpose | Example |
+|----------|---------|---------|
+| `required` | Enforce required values | `{{ required "msg" .Values.x }}` |
+| `default` | Fallback value | `{{ .Values.x \| default 1 }}` |
+| `quote` | Quote strings | `{{ .Values.x \| quote }}` |
+| `include` | Use helpers | `{{ include "name" . \| nindent 4 }}` |
+| `toYaml` | Convert to YAML | `{{ toYaml .Values.x \| nindent 2 }}` |
+| `tpl` | Render as template | `{{ tpl .Values.config . }}` |
+| `nindent` | Newline + indent | `{{- include "x" . \| nindent 4 }}` |
+
 ## Essential Template Functions
 
 ### 1. required - Enforce Required Values

--- a/devops-skills-plugin/skills/helm-generator/references/resource_templates.md
+++ b/devops-skills-plugin/skills/helm-generator/references/resource_templates.md
@@ -29,6 +29,30 @@ Reference templates for common Kubernetes resources with Helm templating.
 - [Autoscaling Resources](#autoscaling-resources)
   - [HorizontalPodAutoscaler](#horizontalpodautoscaler)
   - [PodDisruptionBudget](#poddisruptionbudget)
+- [Required Template Patterns](#required-template-patterns)
+
+---
+
+## Required Template Patterns
+
+Every workload template must include these patterns. Substitute `mychart` with the chart name.
+
+```yaml
+metadata:
+  name: {{ include "mychart.fullname" . }}
+  labels: {{- include "mychart.labels" . | nindent 4 }}
+
+{{- with .Values.nodeSelector }}
+nodeSelector: {{- toYaml . | nindent 2 }}
+{{- end }}
+
+annotations:
+  {{- if and .Values.configMap .Values.configMap.enabled }}
+  checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+  {{- end }}
+```
+
+Checksum annotations are required for workloads, but must be conditional and only reference templates that the chart actually generates (`configmap.yaml`, `secret.yaml`).
 
 ---
 

--- a/devops-skills-plugin/skills/helm-generator/scripts/generate_chart_structure.sh
+++ b/devops-skills-plugin/skills/helm-generator/scripts/generate_chart_structure.sh
@@ -5,6 +5,7 @@
 #
 # Options:
 #   --force             Overwrite existing chart without prompting
+#   --dry-run           Print planned tree and Chart.yaml/values.yaml previews without writing
 #   --image <repo>      Set image repository (default: nginx; supports tag or digest refs)
 #   --tag <tag>         Set image tag (default: uses chart appVersion)
 #   --port <number>     Set service port (default: 80)
@@ -27,6 +28,7 @@ NC='\033[0m' # No Color
 
 # Default values
 FORCE=false
+DRY_RUN=false
 IMAGE_REPO="nginx"
 IMAGE_TAG=""
 IMAGE_DIGEST=""
@@ -270,6 +272,7 @@ Arguments:
 
 Options:
   --force           Overwrite existing chart without prompting
+  --dry-run         Print planned tree and Chart.yaml/values.yaml previews; do not write
   --image <repo>    Set image repository (default: nginx)
                     Supports registry ports, tags, and digest refs:
                     - registry:5000/app
@@ -313,6 +316,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --force)
             FORCE=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
             shift
             ;;
         --image)
@@ -392,6 +399,106 @@ if [ -n "$IMAGE_TAG" ]; then
     validate_image_tag "$IMAGE_TAG"
 fi
 
+IMAGE_DISPLAY="$IMAGE_REPO"
+if [ -n "$IMAGE_DIGEST" ]; then
+    IMAGE_DISPLAY="${IMAGE_REPO}@${IMAGE_DIGEST}"
+elif [ -n "$IMAGE_TAG" ]; then
+    IMAGE_DISPLAY="${IMAGE_REPO}:${IMAGE_TAG}"
+else
+    IMAGE_DISPLAY="${IMAGE_REPO}:<chart appVersion>"
+fi
+
+# Print the planned file tree to stdout.
+print_planned_tree() {
+    echo "${CHART_DIR}/"
+    echo "├── Chart.yaml"
+    echo "├── values.yaml"
+    echo "├── .helmignore"
+    echo "├── templates/"
+    echo "│   ├── _helpers.tpl"
+    echo "│   ├── NOTES.txt"
+    if [ "$WITH_TEMPLATES" = true ]; then
+        echo "│   ├── serviceaccount.yaml"
+        echo "│   ├── service.yaml"
+        echo "│   ├── configmap.yaml"
+        echo "│   ├── secret.yaml"
+        if [ "$WORKLOAD_TYPE" = "statefulset" ]; then
+            echo "│   ├── service-headless.yaml"
+            echo "│   ├── statefulset.yaml"
+        elif [ "$WORKLOAD_TYPE" = "daemonset" ]; then
+            echo "│   ├── daemonset.yaml"
+        else
+            echo "│   ├── deployment.yaml"
+        fi
+        if [ "$WITH_INGRESS" = true ]; then
+            echo "│   ├── ingress.yaml"
+        fi
+        if [ "$WITH_HPA" = true ] && [ "$WORKLOAD_TYPE" != "daemonset" ]; then
+            echo "│   └── hpa.yaml"
+        fi
+    fi
+    echo "└── charts/"
+}
+
+# Render Chart.yaml content to stdout.
+render_chart_yaml_preview() {
+    cat <<EOF
+apiVersion: v2
+name: ${CHART_NAME}
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+EOF
+}
+
+# Render values.yaml header (image/service block) to stdout.
+# Full file is generated at write time; dry-run shows the load-bearing fields users tune.
+render_values_yaml_preview() {
+    cat <<EOF
+# Default values for ${CHART_NAME}.
+replicaCount: 1
+
+image:
+  repository: ${IMAGE_REPO}
+  pullPolicy: IfNotPresent
+  tag: "${IMAGE_TAG}"
+  digest: "${IMAGE_DIGEST}"
+
+service:
+  type: ClusterIP
+  port: ${SERVICE_PORT}
+  targetPort: ${TARGET_PORT}
+  portName: http
+
+# (resources, probes, ingress, autoscaling, configMap, secret, env, volumes,
+#  nodeSelector, tolerations, affinity, and workload-specific blocks omitted in preview)
+EOF
+}
+
+if [ "$DRY_RUN" = true ]; then
+    echo "Dry run: planning Helm chart for: ${CHART_NAME}"
+    echo "  Output directory: ${CHART_DIR}"
+    echo "  Image: ${IMAGE_DISPLAY}"
+    echo "  Service port: ${SERVICE_PORT}"
+    echo "  Target port: ${TARGET_PORT}"
+    echo "  Workload type: ${WORKLOAD_TYPE}"
+    if [ -d "$CHART_DIR" ]; then
+        echo "  Note: ${CHART_DIR} already exists; a real run would prompt or require --force."
+    fi
+    echo
+    echo "Planned file tree:"
+    print_planned_tree
+    echo
+    echo "----- Chart.yaml preview -----"
+    render_chart_yaml_preview
+    echo "----- values.yaml preview -----"
+    render_values_yaml_preview
+    echo "------------------------------"
+    echo "Dry run complete. No files written."
+    exit 0
+fi
+
 # Check if chart directory already exists
 if [ -d "$CHART_DIR" ]; then
     if [ "$FORCE" = true ]; then
@@ -407,15 +514,6 @@ if [ -d "$CHART_DIR" ]; then
         fi
         rm -rf "$CHART_DIR"
     fi
-fi
-
-IMAGE_DISPLAY="$IMAGE_REPO"
-if [ -n "$IMAGE_DIGEST" ]; then
-    IMAGE_DISPLAY="${IMAGE_REPO}@${IMAGE_DIGEST}"
-elif [ -n "$IMAGE_TAG" ]; then
-    IMAGE_DISPLAY="${IMAGE_REPO}:${IMAGE_TAG}"
-else
-    IMAGE_DISPLAY="${IMAGE_REPO}:<chart appVersion>"
 fi
 
 echo "Creating Helm chart structure for: ${CHART_NAME}"

--- a/devops-skills-plugin/skills/k8s-debug/SKILL.md
+++ b/devops-skills-plugin/skills/k8s-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-debug
-description: Diagnose and fix Kubernetes pods, CrashLoopBackOff, Pending, DNS, networking, storage, and rollout failures with kubectl.
+description: Use when diagnosing live Kubernetes failures with kubectl - pod CrashLoopBackOff/Pending/ImagePullBackOff, service/DNS connectivity, PVC binding, rollout stalls, node pressure. Triggers - "pod is crashing", "rollout stuck", "DNS not resolving in pod", "PVC pending", "OOMKilled", "ImagePullBackOff", "service unreachable". Not for authoring manifests, Helm templating, or Terraform-managed cluster provisioning.
 ---
 
 # Kubernetes Debugging Skill
@@ -18,6 +18,10 @@ Use this skill when requests resemble:
 - "Pods are `Pending` and not scheduling."
 - "Cluster health looks degraded after a change."
 - "PVC is pending and pods cannot mount storage."
+- "Pod was OOMKilled" / resource exhaustion (CPU/memory).
+- "ImagePullBackOff after registry change."
+- "NetworkPolicy is blocking traffic" / ingress not routing.
+- "ConfigMap/Secret/RBAC misconfiguration breaks the workload."
 
 ## Prerequisites
 
@@ -27,6 +31,7 @@ Run from the skill directory (`devops-skills-plugin/skills/k8s-debug`) so relati
 - `kubectl` installed and configured.
 - An active cluster context.
 - Read access to namespaces, pods, events, services, and nodes.
+- `python3 >= 3.8` (stdlib only; no third-party packages required).
 
 Quick preflight:
 
@@ -46,23 +51,12 @@ Fallback behavior:
 - If optional tools are missing, scripts continue and print warnings with reduced output.
 - If `kubectl top` is unavailable, continue with `kubectl describe` and events.
 
-## When to Use This Skill
-
-Use this skill for:
-- Pod failures (CrashLoopBackOff, ImagePullBackOff, Pending, OOMKilled)
-- Service connectivity or DNS resolution issues
-- Network policy or ingress problems
-- Volume and storage mount failures
-- Deployment rollout issues
-- Cluster health or performance degradation
-- Resource exhaustion (CPU/memory)
-- Configuration problems (ConfigMaps, Secrets, RBAC)
-
 ## Safety Rules for Disruptive Commands
 
 Default mode is read-only diagnosis first. Only execute disruptive commands after confirming blast radius and rollback.
 
-Commands requiring explicit confirmation:
+STOP and ask the user before executing any of these commands. Print the exact command, the target namespace/resource, and the rollback path, then wait for explicit approval. Do not run them as part of automated diagnosis.
+
 - `kubectl delete pod ... --force --grace-period=0`
 - `kubectl drain ...`
 - `kubectl rollout restart ...`
@@ -247,74 +241,7 @@ Then follow `Service Connectivity Workflow` in `./references/troubleshooting_wor
 
 ## Essential Manual Commands
 
-### Pod Debugging
-
-```bash
-# View pod status
-kubectl get pods -n <namespace> -o wide
-
-# Detailed pod information
-kubectl describe pod <pod-name> -n <namespace>
-
-# View logs
-kubectl logs <pod-name> -n <namespace>
-kubectl logs <pod-name> -n <namespace> --previous  # Previous container
-kubectl logs <pod-name> -n <namespace> -c <container>  # Specific container
-
-# Execute commands in pod
-kubectl exec <pod-name> -n <namespace> -it -- /bin/sh
-
-# Get pod YAML
-kubectl get pod <pod-name> -n <namespace> -o yaml
-```
-
-### Service and Network Debugging
-
-```bash
-# Check services
-kubectl get svc -n <namespace>
-kubectl describe svc <service-name> -n <namespace>
-
-# Check endpoints
-kubectl get endpoints -n <namespace>
-
-# Test DNS
-kubectl exec <pod-name> -n <namespace> -- nslookup kubernetes.default
-
-# View events
-kubectl get events -n <namespace> --sort-by='.lastTimestamp'
-```
-
-### Resource Monitoring
-
-```bash
-# Node resources
-kubectl top nodes
-kubectl describe nodes
-
-# Pod resources
-kubectl top pods -n <namespace>
-kubectl top pod <pod-name> -n <namespace> --containers
-```
-
-### Emergency Operations
-
-```bash
-# Restart deployment
-kubectl rollout restart deployment/<name> -n <namespace>
-
-# Rollback deployment
-kubectl rollout undo deployment/<name> -n <namespace>
-
-# Force delete stuck pod
-kubectl delete pod <pod-name> -n <namespace> --force --grace-period=0
-
-# Drain node (maintenance)
-kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
-
-# Cordon node (prevent scheduling)
-kubectl cordon <node-name>
-```
+See `./references/troubleshooting_workflow.md` (lines 300-350) for the consolidated `kubectl` command reference covering pod, service/network, resource, and emergency operations.
 
 ## Completion Criteria
 

--- a/devops-skills-plugin/skills/k8s-debug/scripts/cluster_health.sh
+++ b/devops-skills-plugin/skills/k8s-debug/scripts/cluster_health.sh
@@ -197,6 +197,9 @@ section "PERSISTENT VOLUMES"
 run_or_warn "PV list" kubectl_cmd get pv
 
 section "COMPONENT STATUS"
+# componentstatuses is deprecated since k8s 1.19 but kept as the third fallback:
+# /readyz and /healthz are unauthenticated on some restricted clusters, and on
+# very old clusters (pre-1.19) componentstatuses is the only signal available.
 run_pipe_or_warn "Component readiness endpoint query" "kubectl --request-timeout=\"$REQUEST_TIMEOUT\" get --raw='/readyz?verbose' 2>/dev/null || kubectl --request-timeout=\"$REQUEST_TIMEOUT\" get --raw='/healthz?verbose' 2>/dev/null || kubectl --request-timeout=\"$REQUEST_TIMEOUT\" get componentstatuses"
 
 section "API SERVER HEALTH"

--- a/devops-skills-plugin/skills/k8s-debug/scripts/pod_diagnostics.py
+++ b/devops-skills-plugin/skills/k8s-debug/scripts/pod_diagnostics.py
@@ -130,6 +130,10 @@ def get_pod_info(pod_name: str, namespace: str = "default") -> None:
 
     for container in containers:
         print(f"\n### Container: {container} ###")
+        # --tail=100: enough lines to capture a typical crash trace + startup banner
+        # without flooding the report on chatty workloads.
+        # timeout=45: log streams from large pods can stall briefly on the API server;
+        # 45s tolerates that without hanging an interactive diagnostic run.
         stdout, stderr, _ = run_kubectl(
             ["logs", pod_name, "-n", namespace, "-c", container, "--tail=100"],
             timeout=45,
@@ -137,6 +141,9 @@ def get_pod_info(pod_name: str, namespace: str = "default") -> None:
         print_output(stdout, stderr)
 
         print(f"\n### Previous logs for: {container} ###")
+        # --tail=50: previous-container logs are post-mortem only; 50 lines is
+        # enough for the final stack trace without doubling report size.
+        # timeout=45: same rationale as the live-log fetch above.
         stdout, stderr, code = run_kubectl(
             ["logs", pod_name, "-n", namespace, "-c", container, "--previous", "--tail=50"],
             timeout=45,
@@ -168,6 +175,9 @@ def get_pod_info(pod_name: str, namespace: str = "default") -> None:
             print_section("INIT CONTAINER LOGS")
             for container in init_containers:
                 print(f"\n### Init Container: {container} ###")
+                # --tail=100: matches main-container budget; init failures often
+                # need the full startup trace to identify the failing step.
+                # timeout=45: matches main-container budget for the same reason.
                 stdout, stderr, _ = run_kubectl(
                     ["logs", pod_name, "-n", namespace, "-c", container, "--tail=100"],
                     timeout=45,
@@ -175,6 +185,8 @@ def get_pod_info(pod_name: str, namespace: str = "default") -> None:
                 print_output(stdout, stderr)
 
                 print(f"\n### Previous init container logs for: {container} ###")
+                # --tail=50: post-mortem-only; smaller budget keeps the report lean.
+                # timeout=45: same rationale as the live init-log fetch above.
                 stdout, stderr, code = run_kubectl(
                     ["logs", pod_name, "-n", namespace, "-c", container, "--previous", "--tail=50"],
                     timeout=45,
@@ -192,6 +204,8 @@ def get_pod_info(pod_name: str, namespace: str = "default") -> None:
 
     # Resource usage
     print_section("RESOURCE USAGE")
+    # timeout=20: metrics-server is either reachable in seconds or unavailable;
+    # a short budget surfaces the missing-metrics case fast instead of blocking.
     stdout, stderr, code = run_kubectl(
         ["top", "pod", pod_name, "-n", namespace, "--containers"],
         timeout=20,

--- a/devops-skills-plugin/skills/promql-generator/SKILL.md
+++ b/devops-skills-plugin/skills/promql-generator/SKILL.md
@@ -1,1063 +1,149 @@
 ---
 name: promql-generator
-description: Generate/create/write PromQL queries, metric expressions, alerting rules, recording rules, Prometheus dashboards.
+description: Use when the user asks to write, generate, or build PromQL queries, alerting rules, recording rules, or SLO/burn-rate expressions for Prometheus or Grafana dashboards. Triggers — "write a Prometheus query", "alert on error rate", "P95 latency", "kube-state-metrics query", "burn rate alert". Not for general Prometheus operator/installation/scrape-config questions.
 ---
 
 # PromQL Query Generator
 
-## Overview
+Generate production-ready PromQL queries (ad-hoc, dashboard, alerting rule, recording rule, SLO/burn-rate). Most generation is direct; collaborative planning is reserved for genuinely ambiguous requests or alerting rules going to production.
 
-This skill provides a comprehensive, interactive workflow for generating production-ready PromQL queries with best practices built-in. Generate queries for monitoring dashboards, alerting rules, and ad-hoc analysis with an emphasis on user collaboration and planning before code generation.
+## When to use
 
-## When to Use This Skill
+- Creating new PromQL queries for dashboards, alerts, recording rules, or analysis
+- Implementing RED (Rate, Errors, Duration) or USE (Utilization, Saturation, Errors) signals
+- SLO / error-budget / burn-rate expressions
+- Converting monitoring requirements into PromQL
 
-Invoke this skill when:
-- Creating new PromQL queries from scratch
-- Building monitoring dashboards (Grafana, Prometheus UI, etc.)
-- Implementing alerting rules for Prometheus Alertmanager
-- Analyzing metrics for troubleshooting or capacity planning
-- Converting monitoring requirements into PromQL expressions
-- Learning PromQL or teaching others
-- The user asks to "create", "generate", "build", or "write" PromQL queries
-- Working with Prometheus metrics (counters, gauges, histograms, summaries)
-- Implementing RED (Rate, Errors, Duration) or USE (Utilization, Saturation, Errors) metrics
+Trigger phrases (non-exhaustive): "write a Prometheus query", "PromQL for…", "alert when error rate > X", "P95 latency for service Y", "kube-state-metrics query for…", "burn rate alert", "recording rule for…".
 
-## Interactive Query Planning Workflow
+Not for: installing/configuring Prometheus, scrape-config debugging, exporter authoring, Grafana dashboard JSON layout, or validating/reviewing existing queries (use `devops-skills:promql-validator` for that).
 
-**CRITICAL**: This skill emphasizes **interactive planning** before query generation. Always engage the user in a collaborative planning process to ensure the generated query matches their exact intentions.
+## Workflow
 
-Follow this workflow when generating PromQL queries:
+### Fast path (default)
 
-### Stage 1: Understand the Monitoring Goal
+If the request specifies metric + service/scope + threshold-or-time-window, generate the query directly. Open the response with a one-line assumption note that surfaces every default you picked, then deliver the query and a short usage block.
 
-Start by understanding what the user wants to monitor or measure. Ask clarifying questions to gather requirements:
+Example assumption note:
+> Assuming counter `http_requests_total` with labels `job`, `status_code`; rate window `[5m]`; SLO threshold `> 5%`; output as ratio (0–1).
 
-1. **Primary Goal**: What are you trying to monitor or measure?
-   - Request rate (requests per second)
-   - Error rate (percentage of failed requests)
-   - Latency/duration (response times, percentiles)
-   - Resource usage (CPU, memory, disk, network)
-   - Availability/uptime
-   - Queue depth, saturation, throughput
-   - Custom business metrics
+What "specified enough" means:
+- A concrete metric name or unambiguous metric category (e.g. "5xx error rate on http_requests_total", "P95 latency from `http_request_duration_seconds`").
+- A target service / job / scope (`job="api"`, namespace, deployment, etc.).
+- A threshold and/or time window for alerts; just a window for graphs.
 
-2. **Use Case**: What will this query be used for?
-   - Dashboard visualization (Grafana, Prometheus UI)
-   - Alerting rule (firing when threshold exceeded)
-   - Ad-hoc troubleshooting/analysis
-   - Recording rule (pre-computed aggregation)
-   - Capacity planning or SLO tracking
+### Plan-confirm path (use only when warranted)
 
-3. **Context**: Any additional context?
-   - Service/application name
-   - Team or project
-   - Priority level
-   - Existing metrics or naming conventions
+Switch to a plan-confirm-validate loop when any of these hold:
+- The metric, metric type, or label set is unknown or ambiguous.
+- The user is asking for an alerting rule that will go to production (page-grade or shared SLO).
+- The request mixes signals (e.g. error rate AND latency) without specifying combination semantics.
+- Cardinality, cost, or aggregation level materially changes the answer and the user has not picked one.
 
-Use the **AskUserQuestion** tool to gather this information if not provided.
+In that mode:
+1. Confirm goal, metric(s) + type, labels, window, aggregation, and threshold. Use `AskUserQuestion` if available, otherwise a single inline questionnaire.
+2. Present a plain-English plan: which metric, which function, what the result means, expected labels, expected value range. Ask for confirmation, with options to modify or to see alternatives (offer at least two with trade-offs).
+3. Generate the query only after confirmation.
 
-> **When to Ask vs. Infer**: If the user's initial request already clearly specifies the goal, use case, and context (e.g., "Create an alert for P95 latency > 500ms for payment-service"), you may acknowledge these details in your response instead of re-asking. Only ask clarifying questions for information that is missing or ambiguous.
+If `AskUserQuestion` is unavailable, batch all needed questions into one message; if the user only answers some, proceed with conservative defaults and mark assumptions explicitly.
 
-### Stage 2: Identify Available Metrics
+### Reference reads
 
-Determine which metrics are available and relevant:
+Read references when any of:
+- Histogram or summary quantiles are involved (see `references/metric_types.md`, `references/promql_functions.md`).
+- Joins / vector matching, subqueries, offsets, `@` modifier, or recording/alerting rules (`references/promql_patterns.md`, `references/promql_functions.md`).
+- SLO / burn-rate / error-budget patterns (`examples/slo_patterns.promql`).
+- Optimization or cardinality concerns (`references/best_practices.md`).
+- Metric type or labels are unknown.
 
-1. **Metric Discovery**: What metrics are available?
-   - Ask the user for metric names
-   - If uncertain, suggest common naming patterns
-   - Check for metric type indicators in the name:
-     - `_total` suffix → Counter
-     - `_bucket`, `_sum`, `_count` suffix → Histogram
-     - No suffix → Likely Gauge
-     - `_created` suffix → Counter creation timestamp
+Skip reference reads only when the request is single-metric + single-function (`rate`, `increase`, `sum`, `avg`, `max`, `min`), no joins, no rules, and metric type is clearly given. State `Reference read skipped (trivial case)` when you skip.
 
-2. **Metric Type Identification**: Confirm the metric type(s)
-   - **Counter**: Cumulative metric that only increases (or resets to zero)
-     - Examples: `http_requests_total`, `errors_total`, `bytes_sent_total`
-     - Use with: `rate()`, `irate()`, `increase()`
-   - **Gauge**: Point-in-time value that can go up or down
-     - Examples: `memory_usage_bytes`, `cpu_temperature_celsius`, `queue_length`
-     - Use with: `avg_over_time()`, `min_over_time()`, `max_over_time()`, or directly
-   - **Histogram**: Buckets of observations with cumulative counts
-     - Examples: `http_request_duration_seconds_bucket`, `response_size_bytes_bucket`
-     - Use with: `histogram_quantile()`, `rate()`
-   - **Summary**: Pre-calculated quantiles with count and sum
-     - Examples: `rpc_duration_seconds{quantile="0.95"}`
-     - Use `_sum` and `_count` for averages; don't average quantiles
+Cite the pattern you used (file + section) so the user can audit.
 
-3. **Label Discovery**: What labels are available on these metrics?
-   - Common labels: `job`, `instance`, `environment`, `service`, `endpoint`, `status_code`, `method`
-   - Ask which labels are important for filtering or grouping
+### Validation flow
 
-Use the **AskUserQuestion** tool to confirm metric names, types, and available labels.
-
-### Stage 3: Determine Query Parameters
-
-Gather specific requirements for the query.
-
-#### Pre-confirmation for User-Provided Parameters
-
-**IMPORTANT**: When the user has already specified parameters in their initial request (e.g., "5-minute window", "500ms threshold", "> 5% error rate"), you MUST:
-
-1. **Acknowledge the provided values** explicitly in your response
-2. **Present them as pre-filled defaults** in AskUserQuestion with the first option being "Use specified values"
-3. **Allow quick confirmation** rather than re-asking for information already given
-
-**Example**: If user says "alert when P95 latency exceeds 500ms", use:
-```
-AskUserQuestion:
-- Question: "Confirm the alert threshold?"
-- Options:
-  1. "500ms (as specified)" - Use the threshold from your request
-  2. "Different threshold" - Let me specify a different value
-```
-
-This respects the user's input and speeds up the workflow while still allowing modifications.
-
-1. **Time Range**: What time window should the query cover?
-   - Instant value (current)
-   - Rate over time (`[5m]`, `[1h]`, `[1d]`)
-   - For rate calculations: typically `[1m]` to `[5m]` for real-time, `[1h]` to `[1d]` for trends
-   - Rule of thumb: Rate range should be at least 4x the scrape interval
-
-2. **Label Filtering**: Which labels should filter the data?
-   - Exact matches: `job="api-server"`, `status_code="200"`
-   - Negative matches: `status_code!="200"`
-   - Regex matches: `instance=~"prod-.*"`
-   - Multiple conditions: `{job="api", environment="production"}`
-
-3. **Aggregation**: Should the data be aggregated?
-   - **No aggregation**: Return all time series as-is
-   - **Aggregate by labels**: `sum by (job, endpoint)`, `avg by (instance)`
-   - **Aggregate without labels**: `sum without (instance, pod)`, `avg without (job)`
-   - Common aggregations: `sum`, `avg`, `max`, `min`, `count`, `topk`, `bottomk`
-
-4. **Thresholds or Conditions**: Are there specific conditions?
-   - For alerting: threshold values (e.g., error rate > 5%)
-   - For filtering: only show series above/below a value
-   - For comparison: compare against historical data (offset)
-
-Use the **AskUserQuestion** tool to gather or confirm these parameters. When the user has already provided values (e.g., "5-minute window", "> 5%"), present them as the default option for confirmation.
-
-### Stage 4: Present the Query Plan
-
-**BEFORE GENERATING ANY CODE**, present a plain-English query plan and ask for user confirmation:
+After generating a query, hand off to the validator:
 
 ```
-## PromQL Query Plan
-
-Based on your requirements, here's what the query will do:
-
-**Goal**: [Describe the monitoring goal in plain English]
-
-**Query Structure**:
-1. Start with metric: `[metric_name]`
-2. Filter by labels: `{label1="value1", label2="value2"}`
-3. Apply function: `[function_name]([metric][time_range])`
-4. Aggregate: `[aggregation] by ([label_list])`
-5. Additional operations: [any calculations, ratios, or transformations]
-
-**Expected Output**:
-- Data type: [instant vector/scalar]
-- Labels in result: [list of labels]
-- Value represents: [what the number means]
-- Typical range: [expected value range]
-
-**Example Interpretation**:
-If the query returns `0.05`, it means: [plain English explanation]
-
-**Does this match your intentions?**
-- If yes, I'll generate the query and validate it
-- If no, let me know what needs to change
-```
-
-Use the **AskUserQuestion** tool to confirm the plan with options:
-- "Yes, generate this query"
-- "Modify [specific aspect]"
-- "Show me alternative approaches"
-
-When the user chooses:
-- **"Modify [specific aspect]"**: ask one focused follow-up question about what to change (metric, labels, function, time range, threshold, or output shape), then present an updated plan before generating.
-- **"Show me alternative approaches"**: provide at least two valid query plans with trade-offs (accuracy, cost, cardinality, readability), then ask the user to choose one before generating.
-
-### Stage 5: Generate the PromQL Query
-
-Once the user confirms the plan, generate the actual PromQL query following best practices.
-
-#### IMPORTANT: Consult Reference Files Before Generating
-
-**Before writing any query code**, you MUST:
-
-1. **Identify the query category** first (histogram, RED, USE, function-specific, optimization, etc.).
-
-2. **Read only the relevant reference section(s)** using the Read tool:
-   - For histogram queries → Read `references/metric_types.md` (Histogram section)
-   - For error/latency patterns → Read `references/promql_patterns.md` (RED method section)
-   - For resource monitoring → Read `references/promql_patterns.md` (USE method section)
-   - For optimization questions → Read `references/best_practices.md`
-   - For specific functions → Read `references/promql_functions.md`
-   - Re-read a section only if requirements changed or you have not consulted it yet in the current thread.
-
-3. **If a needed reference cannot be read**, state the issue and continue with best-effort generation using the most applicable documented pattern you already have.
-
-4. **Cite the applicable pattern or best practice** in your response:
-   ```
-   As documented in references/promql_patterns.md (Pattern 3: Latency Percentile):
-   # 95th percentile latency
-   histogram_quantile(0.95, sum by (le) (rate(...)))
-   ```
-
-5. **Reference example files** when generating similar queries:
-   ```
-   Based on examples/red_method.promql (lines 64-82):
-   # P95 latency with proper histogram_quantile usage
-   ```
-
-This keeps generated queries aligned with documented patterns while avoiding unnecessary full-file rereads on iterative follow-ups.
-
-#### Best Practices for Query Generation
-
-1. **Always Use Label Filters**
-   ```promql
-   # Good: Specific filtering reduces cardinality
-   rate(http_requests_total{job="api-server", environment="prod"}[5m])
-
-   # Bad: Matches all time series, high cardinality
-   rate(http_requests_total[5m])
-   ```
-
-2. **Use Appropriate Functions for Metric Types**
-   ```promql
-   # Counter: Use rate() or increase()
-   rate(http_requests_total[5m])
-
-   # Gauge: Use directly or with *_over_time()
-   memory_usage_bytes
-   avg_over_time(memory_usage_bytes[5m])
-
-   # Histogram: Use histogram_quantile()
-   histogram_quantile(0.95,
-     sum by (le) (rate(http_request_duration_seconds_bucket[5m]))
-   )
-   ```
-
-3. **Apply Aggregations with by() or without()**
-   ```promql
-   # Aggregate by specific labels (keeps only these labels)
-   sum by (job, endpoint) (rate(http_requests_total[5m]))
-
-   # Aggregate without specific labels (removes these labels)
-   sum without (instance, pod) (rate(http_requests_total[5m]))
-   ```
-
-4. **Use Exact Matches Over Regex When Possible**
-   ```promql
-   # Good: Faster exact match
-   http_requests_total{status_code="200"}
-
-   # Bad: Slower regex match when not needed
-   http_requests_total{status_code=~"200"}
-   ```
-
-5. **Calculate Ratios Properly**
-   ```promql
-   # Error rate: errors / total requests
-   sum(rate(http_requests_total{status_code=~"5.."}[5m]))
-   /
-   sum(rate(http_requests_total[5m]))
-   ```
-
-6. **Use Recording Rules for Complex Queries**
-   - If a query is used frequently or is computationally expensive
-   - Pre-aggregate data to reduce query load
-   - Follow naming convention: `level:metric:operations`
-
-7. **Format for Readability**
-   ```promql
-   # Good: Multi-line for complex queries
-   histogram_quantile(0.95,
-     sum by (le, job) (
-       rate(http_request_duration_seconds_bucket{job="api-server"}[5m])
-     )
-   )
-   ```
-
-#### Common Query Patterns
-
-**Pattern 1: Request Rate**
-```promql
-# Requests per second
-rate(http_requests_total{job="api-server"}[5m])
-
-# Total requests per second across all instances
-sum(rate(http_requests_total{job="api-server"}[5m]))
-```
-
-**Pattern 2: Error Rate**
-```promql
-# Error ratio (0 to 1)
-sum(rate(http_requests_total{job="api-server", status_code=~"5.."}[5m]))
-/
-sum(rate(http_requests_total{job="api-server"}[5m]))
-
-# Error percentage (0 to 100)
-(
-  sum(rate(http_requests_total{job="api-server", status_code=~"5.."}[5m]))
-  /
-  sum(rate(http_requests_total{job="api-server"}[5m]))
-) * 100
-```
-
-**Pattern 3: Latency Percentile (Histogram)**
-```promql
-# 95th percentile latency
-histogram_quantile(0.95,
-  sum by (le) (
-    rate(http_request_duration_seconds_bucket{job="api-server"}[5m])
-  )
-)
-```
-
-**Pattern 4: Resource Usage**
-```promql
-# Current memory usage
-process_resident_memory_bytes{job="api-server"}
-
-# Average CPU usage over 5 minutes
-avg_over_time(process_cpu_seconds_total{job="api-server"}[5m])
-```
-
-**Pattern 5: Availability**
-```promql
-# Percentage of up instances
-(
-  count(up{job="api-server"} == 1)
-  /
-  count(up{job="api-server"})
-) * 100
-```
-
-**Pattern 6: Saturation/Queue Depth**
-```promql
-# Average queue length
-avg_over_time(queue_depth{job="worker"}[5m])
-
-# Maximum queue depth in the last hour
-max_over_time(queue_depth{job="worker"}[1h])
-```
-
-### Stage 6: Validate the Generated Query
-
-**ALWAYS attempt to validate the generated query first** using the devops-skills:promql-validator skill:
-
-```
-After generating the query, automatically invoke:
 Skill(devops-skills:promql-validator)
-
-The devops-skills:promql-validator skill will:
-1. Check syntax correctness
-2. Validate semantic logic (correct functions for metric types)
-3. Identify anti-patterns and inefficiencies
-4. Suggest optimizations
-5. Explain what the query does
-6. Verify it matches user intent
 ```
 
-**Validation checklist**:
-- Syntax is correct (balanced brackets, valid operators)
-- Metric type matches function usage
-- Label filters are specific enough
-- Aggregation is appropriate
-- Time ranges are reasonable
-- No known anti-patterns
-- Query is optimized for performance
+The validator covers: syntax, metric-type/function compatibility, anti-patterns, performance/cardinality, intent match.
 
-If validation fails, fix issues and re-validate until all checks pass.
+If the validator passes, deliver. If it flags issues, fix and re-validate. Cap at two fix/re-validate cycles. If the validator skill is unavailable, fails, or stalls after two cycles:
 
-If the validator skill is unavailable, fails to run, or cannot complete after two fix/re-validate cycles:
-- Report the validator failure briefly (tool unavailable, timeout, parsing error, etc.).
-- Run a manual fallback check (syntax shape, metric/function compatibility, label filtering, aggregation, time range sanity).
-- Mark any unchecked areas as **UNVERIFIED** and ask the user whether to proceed with best-effort output or provide more context for another validation attempt.
+- Report the failure mode briefly (unavailable / timeout / parse error).
+- Run a manual fallback check: balanced brackets, function-vs-metric-type compatibility, label filters, aggregation correctness, time-range sanity.
+- Mark anything you could not check as `UNVERIFIED` and ask the user whether to proceed or supply more context. IMPORTANT: never silently skip validation — surface the gap.
 
-**IMPORTANT: Display Validation Results to User**
-
-After running validation, you MUST display the structured results to the user in this format:
+Display validation results in a short structured block:
 
 ```
-## PromQL Validation Results
-
-### Syntax Check
-- Status: ✅ VALID / ⚠️ WARNING / ❌ ERROR / ⚠️ UNVERIFIED
-- Issues: [list any syntax errors]
-
-### Best Practices Check
-- Status: ✅ OPTIMIZED / ⚠️ CAN BE IMPROVED / ❌ HAS ISSUES / ⚠️ UNVERIFIED
-- Issues: [list any problems found]
-- Suggestions: [list optimization opportunities]
-
-### Validation Coverage
-- Validator tool run: [successful / failed / unavailable]
-- Checks completed: [syntax, semantics, anti-patterns, performance, intent-match]
-- Checks skipped: [list any skipped checks, or "None"]
-
-### Query Explanation
-- **What it measures**: [plain English description]
-- **Output labels**: [list labels in result, or "None (scalar)"]
-- **Expected result structure**: [instant vector / scalar / etc.]
+## Validation Results
+- Syntax:        VALID | WARNING | ERROR | UNVERIFIED   [notes]
+- Best practice: OK | IMPROVABLE | ISSUES | UNVERIFIED  [notes / suggestions]
+- Validator run: ok | failed | unavailable              [coverage gaps]
+- What it measures: <plain-English summary>
+- Output shape:     <instant vector / scalar / labels kept>
 ```
 
-This transparency helps users understand the validation process and any recommendations.
-
-### Stage 7: Provide Usage Instructions
-
-After generation and validation (or manual fallback validation), provide the user with:
-
-1. **The Final Query**:
-   ```promql
-   [Generated and validated PromQL query]
-   ```
-
-2. **Query Explanation**:
-   - What the query measures
-   - How to interpret the results
-   - Expected value range
-   - Labels in the output
-
-3. **How to Use It**:
-   - **For Dashboards**: Copy into Grafana/Prometheus UI panel query
-   - **For Alerts**: Integrate into Alertmanager rule with threshold
-   - **For Recording Rules**: Add to Prometheus recording rule config
-   - **For Ad-hoc**: Run directly in Prometheus expression browser
-
-4. **Customization Notes**:
-   - Time ranges that might need adjustment
-   - Labels to modify for different environments
-   - Threshold values to tune
-   - Alternative functions if requirements change
-
-5. **Related Queries**:
-   - Suggest complementary queries
-   - Mention recording rule opportunities
-   - Recommend dashboard panels
-
-## Native Histograms (Prometheus 3.x+)
-
-Native histograms are now **stable** in Prometheus 3.0+ (released November 2024). They offer significant advantages over classic histograms:
-- Sparse bucket representation with near-zero cost for empty buckets
-- No configuration of bucket boundaries during instrumentation
-- Coverage of the full float64 range
-- Efficient mergeability across histograms
-- Simpler query syntax
-
-> **Important**: Starting with Prometheus v3.8.0, native histograms are fully stable. However, scraping native histograms still requires explicit activation via the `scrape_native_histograms` configuration setting. Starting with v3.9, no feature flag is needed but `scrape_native_histograms` must be set explicitly.
-
-### Native vs Classic Histogram Syntax
-
-```promql
-# Classic histogram (requires _bucket suffix and le label)
-histogram_quantile(0.95,
-  sum by (job, le) (rate(http_request_duration_seconds_bucket[5m]))
-)
-
-# Native histogram (simpler - no _bucket suffix, no le label needed)
-histogram_quantile(0.95,
-  sum by (job) (rate(http_request_duration_seconds[5m]))
-)
-```
-
-### Native Histogram Functions
-
-```promql
-# Get observation count rate from native histogram
-histogram_count(rate(http_request_duration_seconds[5m]))
-
-# Get sum of observations from native histogram
-histogram_sum(rate(http_request_duration_seconds[5m]))
-
-# Calculate fraction of observations between two values
-histogram_fraction(0, 0.1, rate(http_request_duration_seconds[5m]))
-
-# Average request duration from native histogram
-histogram_sum(rate(http_request_duration_seconds[5m]))
-/
-histogram_count(rate(http_request_duration_seconds[5m]))
-```
-
-### Detecting Native vs Classic Histograms
-
-Native histograms are identified by:
-- **No `_bucket` suffix** on the metric name
-- **No `le` label** in the time series
-- The metric stores histogram data directly (not separate bucket counters)
-
-When querying, check if your Prometheus instance has native histograms enabled:
-```yaml
-# prometheus.yml - Enable native histogram scraping
-scrape_configs:
-  - job_name: 'my-app'
-    scrape_native_histogram: true  # Prometheus 3.x+
-```
-
-### Custom Bucket Native Histograms (NHCB)
-
-Prometheus 3.4+ supports custom bucket native histograms (schema -53), allowing classic histogram to native histogram conversion. This is a key migration path for users with existing classic histograms.
-
-**Benefits of NHCB**:
-- Keep existing instrumentation (no code changes needed)
-- Store classic histograms as native histograms for lower costs
-- Query with native histogram syntax
-- Improved reliability and compression
-
-**Configuration** (Prometheus 3.4+):
-```yaml
-# prometheus.yml - Convert classic histograms to NHCB on scrape
-global:
-  scrape_configs:
-    - job_name: 'my-app'
-      convert_classic_histograms_to_nhcb: true  # Prometheus 3.4+
-```
-
-**Querying NHCB**:
-```promql
-# Query NHCB metrics the same way as native histograms
-histogram_quantile(0.95, sum by (job) (rate(http_request_duration_seconds[5m])))
-
-# histogram_fraction also works with NHCB (Prometheus 3.4+)
-histogram_fraction(0, 0.2, rate(http_request_duration_seconds[5m]))
-```
-
-**Note**: Schema -53 indicates custom bucket boundaries. These histograms with different custom bucket boundaries are generally not mergeable with each other.
-
----
-
-## SLO, Error Budget, and Burn Rate Patterns
-
-Service Level Objectives (SLOs) are critical for modern SRE practices. These patterns help implement SLO-based monitoring and alerting.
-
-### Error Budget Calculation
-
-```promql
-# Error budget remaining (for 99.9% SLO over 30 days)
-# Returns value between 0 and 1 (1 = full budget, 0 = exhausted)
-1 - (
-  sum(rate(http_requests_total{job="api", status_code=~"5.."}[30d]))
-  /
-  sum(rate(http_requests_total{job="api"}[30d]))
-) / 0.001  # 0.001 = 1 - 0.999 (allowed error rate)
-
-# Simplified: Availability over 30 days
-sum(rate(http_requests_total{job="api", status_code!~"5.."}[30d]))
-/
-sum(rate(http_requests_total{job="api"}[30d]))
-```
-
-### Burn Rate Calculation
-
-Burn rate measures how fast you're consuming error budget. A burn rate of 1 means you'll exhaust the budget exactly at the end of the SLO window.
-
-```promql
-# Current burn rate (1 hour window, 99.9% SLO)
-# Burn rate = (current error rate) / (allowed error rate)
-(
-  sum(rate(http_requests_total{job="api", status_code=~"5.."}[1h]))
-  /
-  sum(rate(http_requests_total{job="api"}[1h]))
-) / 0.001  # 0.001 = allowed error rate for 99.9% SLO
-
-# Burn rate > 1 means consuming budget faster than allowed
-# Burn rate of 14.4 consumes 2% of monthly budget in 1 hour
-```
-
-### Multi-Window, Multi-Burn-Rate Alerts (Google SRE Standard)
-
-The recommended approach for SLO alerting uses multiple windows to balance detection speed and precision:
-
-```promql
-# Page-level alert: 2% budget in 1 hour (burn rate 14.4)
-# Long window (1h) AND short window (5m) must both exceed threshold
-(
-  (
-    sum(rate(http_requests_total{job="api", status_code=~"5.."}[1h]))
-    /
-    sum(rate(http_requests_total{job="api"}[1h]))
-  ) > 14.4 * 0.001
-)
-and
-(
-  (
-    sum(rate(http_requests_total{job="api", status_code=~"5.."}[5m]))
-    /
-    sum(rate(http_requests_total{job="api"}[5m]))
-  ) > 14.4 * 0.001
-)
-
-# Ticket-level alert: 5% budget in 6 hours (burn rate 6)
-(
-  (
-    sum(rate(http_requests_total{job="api", status_code=~"5.."}[6h]))
-    /
-    sum(rate(http_requests_total{job="api"}[6h]))
-  ) > 6 * 0.001
-)
-and
-(
-  (
-    sum(rate(http_requests_total{job="api", status_code=~"5.."}[30m]))
-    /
-    sum(rate(http_requests_total{job="api"}[30m]))
-  ) > 6 * 0.001
-)
-```
-
-### SLO Recording Rules
-
-Pre-compute SLO metrics for efficient alerting:
-
-```yaml
-# Recording rules for SLO calculations
-groups:
-  - name: slo_recording_rules
-    interval: 30s
-    rules:
-      # Error ratio over different windows
-      - record: job:slo_errors_per_request:ratio_rate1h
-        expr: |
-          sum by (job) (rate(http_requests_total{status_code=~"5.."}[1h]))
-          /
-          sum by (job) (rate(http_requests_total[1h]))
-
-      - record: job:slo_errors_per_request:ratio_rate5m
-        expr: |
-          sum by (job) (rate(http_requests_total{status_code=~"5.."}[5m]))
-          /
-          sum by (job) (rate(http_requests_total[5m]))
-
-      # Availability (success ratio)
-      - record: job:slo_availability:ratio_rate1h
-        expr: |
-          1 - job:slo_errors_per_request:ratio_rate1h
-```
-
-### Latency SLO Queries
-
-```promql
-# Percentage of requests faster than SLO target (200ms)
-(
-  sum(rate(http_request_duration_seconds_bucket{le="0.2", job="api"}[5m]))
-  /
-  sum(rate(http_request_duration_seconds_count{job="api"}[5m]))
-) * 100
-
-# Requests violating latency SLO (slower than 500ms)
-(
-  sum(rate(http_request_duration_seconds_count{job="api"}[5m]))
-  -
-  sum(rate(http_request_duration_seconds_bucket{le="0.5", job="api"}[5m]))
-)
-/
-sum(rate(http_request_duration_seconds_count{job="api"}[5m]))
-```
-
-### Burn Rate Reference Table
-
-| Burn Rate | Budget Consumed | Time to Exhaust 30-day Budget | Alert Severity |
-|-----------|-----------------|-------------------------------|----------------|
-| 1         | 100% over 30d   | 30 days                       | None           |
-| 2         | 100% over 15d   | 15 days                       | Low            |
-| 6         | 5% in 6h        | 5 days                        | Ticket         |
-| 14.4      | 2% in 1h        | ~2 days                       | Page           |
-| 36        | 5% in 1h        | ~20 hours                     | Page (urgent)  |
-
----
-
-## Advanced Query Techniques
-
-### Using Subqueries
-
-Subqueries enable complex time-based calculations:
-
-```promql
-# Maximum 5-minute rate over the past 30 minutes
-max_over_time(
-  rate(http_requests_total[5m])[30m:1m]
-)
-```
-
-**Syntax**: `<query>[<range>:<resolution>]`
-- `<range>`: Time window to evaluate over
-- `<resolution>`: Step size between evaluations
-
-### Using Offset Modifier
-
-Compare current data with historical data:
-
-```promql
-# Compare current rate with rate from 1 week ago
-rate(http_requests_total[5m])
--
-rate(http_requests_total[5m] offset 1w)
-```
-
-### Using @ Modifier
-
-Query metrics at specific timestamps:
-
-```promql
-# Rate at the end of the range query
-rate(http_requests_total[5m] @ end())
-
-# Rate at specific Unix timestamp
-rate(http_requests_total[5m] @ 1609459200)
-```
-
-### Binary Operators and Vector Matching
-
-Combine metrics with operators and control label matching:
-
-```promql
-# One-to-one matching (default)
-metric_a + metric_b
-
-# Many-to-one with group_left
-rate(http_requests_total[5m])
-* on (job, instance) group_left (version)
-  app_version_info
-
-# Ignoring specific labels
-metric_a + ignoring(instance) metric_b
-```
-
-### Logical Operators
-
-Filter time series based on conditions:
-
-```promql
-# Return series only where value > 100
-http_requests_total > 100
-
-# Return series present in both
-metric_a and metric_b
-
-# Return series in A but not in B
-metric_a unless metric_b
-```
-
-## Documentation Lookup
-
-If the user asks about specific Prometheus features, operators, or custom metrics:
-
-1. **Try context7 MCP first (preferred)**:
-   ```
-   Use mcp__context7__resolve-library-id with "prometheus"
-   Then use mcp__context7__get-library-docs with:
-   - context7CompatibleLibraryID: /prometheus/docs
-   - topic: [specific feature, function, or operator]
-   - page: 1 (fetch additional pages if needed)
-   ```
-
-2. **Fallback to WebSearch**:
-   ```
-   Search query pattern:
-   "Prometheus PromQL [function/operator/feature] documentation [version] examples"
-
-   Examples:
-   "Prometheus PromQL rate function documentation examples"
-   "Prometheus PromQL histogram_quantile documentation best practices"
-   "Prometheus PromQL aggregation operators documentation"
-   ```
-
-## Common Monitoring Scenarios
-
-### RED Method (for Request-Driven Services)
-
-1. **Rate**: Request throughput
-   ```promql
-   sum(rate(http_requests_total{job="api"}[5m])) by (endpoint)
-   ```
-
-2. **Errors**: Error rate
-   ```promql
-   sum(rate(http_requests_total{job="api", status_code=~"5.."}[5m]))
-   /
-   sum(rate(http_requests_total{job="api"}[5m]))
-   ```
-
-3. **Duration**: Latency percentiles
-   ```promql
-   histogram_quantile(0.95,
-     sum by (le) (rate(http_request_duration_seconds_bucket{job="api"}[5m]))
-   )
-   ```
-
-### USE Method (for Resources)
-
-1. **Utilization**: Resource usage percentage
-   ```promql
-   (
-     avg(rate(node_cpu_seconds_total{mode!="idle"}[5m]))
-     /
-     count(node_cpu_seconds_total{mode="idle"})
-   ) * 100
-   ```
-
-2. **Saturation**: Queue depth or resource contention
-   ```promql
-   avg_over_time(node_load1[5m])
-   ```
-
-3. **Errors**: Error counters
-   ```promql
-   rate(node_network_receive_errs_total[5m])
-   ```
-
-## Alerting Rules
-
-When generating queries for alerting:
-
-1. **Include the Threshold**: Make the condition explicit
-   ```promql
-   # Alert when error rate exceeds 5%
-   (
-     sum(rate(http_requests_total{status_code=~"5.."}[5m]))
-     /
-     sum(rate(http_requests_total[5m]))
-   ) > 0.05
-   ```
-
-2. **Use Boolean Operators**: Return 1 (fire) or 0 (no alert)
-   ```promql
-   # Returns 1 when memory usage > 90%
-   (process_resident_memory_bytes / node_memory_MemTotal_bytes) > 0.9
-   ```
-
-3. **Consider for Duration**: Alerts typically use `for` clause
-   ```yaml
-   alert: HighErrorRate
-   expr: |
-     (
-       sum(rate(http_requests_total{status_code=~"5.."}[5m]))
-       /
-       sum(rate(http_requests_total[5m]))
-     ) > 0.05
-   for: 10m  # Only fire after 10 minutes of continuous violation
-   ```
-
-## Recording Rules
-
-When generating queries for recording rules:
-
-1. **Follow Naming Convention**: `level:metric:operations`
-   ```yaml
-   # level: aggregation level (job, instance, etc.)
-   # metric: base metric name
-   # operations: functions applied
-
-   - record: job:http_requests:rate5m
-     expr: sum by (job) (rate(http_requests_total[5m]))
-   ```
-
-2. **Pre-aggregate Expensive Queries**:
-   ```yaml
-   # Recording rule for frequently-used latency query
-   - record: job_endpoint:http_request_duration_seconds:p95
-     expr: |
-       histogram_quantile(0.95,
-         sum by (job, endpoint, le) (
-           rate(http_request_duration_seconds_bucket[5m])
-         )
-       )
-   ```
-
-3. **Use Recorded Metrics in Dashboards**:
-   ```promql
-   # Instead of expensive query, use pre-recorded metric
-   job_endpoint:http_request_duration_seconds:p95{job="api-server"}
-   ```
-
-## Error Handling
-
-### Common Issues and Solutions
-
-1. **Empty Results**:
-   - Check if metrics exist: `up{job="your-job"}`
-   - Verify label filters are correct
-   - Check time range is appropriate
-   - Confirm metric is being scraped
-
-2. **Too Many Series (High Cardinality)**:
-   - Add more specific label filters
-   - Use aggregation to reduce series count
-   - Consider using recording rules
-   - Check for label explosion (dynamic labels)
-
-3. **Incorrect Values**:
-   - Verify metric type (counter vs gauge)
-   - Check function usage (rate on counters, not gauges)
-   - Verify time range is appropriate
-   - Check for counter resets
-
-4. **Performance Issues**:
-   - Reduce time range for range vectors
-   - Add label filters to reduce cardinality
-   - Use recording rules for complex queries
-   - Avoid expensive regex patterns
-   - Consider query timeout settings
-
-## Communication Guidelines
-
-When generating queries:
-
-1. **Explain the Plan**: Always present a plain-English plan before generating
-2. **Ask Questions**: Use AskUserQuestion tool to gather requirements
-3. **Confirm Intent**: Verify the query matches user goals before finalizing
-4. **Educate**: Explain why certain functions or patterns are used
-5. **Provide Context**: Show how to interpret results
-6. **Suggest Improvements**: Offer optimizations or alternative approaches
-7. **Validate Proactively**: Always validate and fix issues
-8. **Follow Up**: Ask if adjustments are needed
-
-## Fallback When AskUserQuestion Is Unavailable
-
-If a structured question tool is unavailable, continue with an explicit inline questionnaire in plain text:
-1. Ask for goal, metric names/types, labels, time range, aggregation, and use case in one compact prompt.
-2. If the user provides partial answers, proceed with conservative defaults and clearly mark assumptions.
-3. If core inputs are still ambiguous, offer 2-3 concrete query-plan options and ask the user to pick one.
-4. Do not block generation indefinitely waiting for perfect context; generate a best-effort query with assumption notes.
-
-## Relevant Reference Criteria and Trivial-Case Skip Rules
-
-Use references deterministically, but avoid unnecessary reads for trivial requests.
-
-Read references when ANY of the following is true:
-- Histogram or summary quantiles are requested
-- Query uses joins/vector matching, subqueries, offsets, or recording/alerting rules
-- Query is for SLO/burn-rate/error-budget workflows
-- Query includes optimization or cardinality concerns
-- Metric type is unknown or contested
-
-Skip reference reads only when ALL of the following are true:
-- Single-metric, single-function query (`rate`, `increase`, `sum`, `avg`, `max`, `min`)
-- No joins, no recording/alert rules, no advanced functions
-- Metric type and labels are clearly provided by the user
-
-When skipping, explicitly state: `Reference read skipped (trivial case)` and keep validation mandatory.
-
-## Integration with devops-skills:promql-validator
-
-After generating any PromQL query, **automatically invoke the devops-skills:promql-validator skill** to ensure quality:
-
-```
-Steps:
-1. Generate the PromQL query based on user requirements
-2. Invoke devops-skills:promql-validator skill with the generated query
-3. Review validation results (syntax, semantics, performance)
-4. Fix any issues identified by the validator
-5. Re-validate until all checks pass
-6. Provide the final validated query with usage instructions
-7. Ask user if further refinements are needed
-```
-
-This ensures all generated queries follow best practices and are production-ready.
-
-## Resources
-
-> **IMPORTANT: Explicit Reference Consultation**
->
-> When generating queries, you SHOULD explicitly read the relevant reference files using the Read tool and cite applicable best practices. This ensures generated queries follow documented patterns and helps users understand why certain approaches are recommended.
-
-### references/
-
-**promql_functions.md**
-- Comprehensive reference of all PromQL functions
-- Grouped by category (aggregation, math, time, histogram, etc.)
-- Usage examples for each function
-- **Read this file when**: implementing specific function requirements or when user asks about function behavior
-
-**promql_patterns.md**
-- Common query patterns for typical monitoring scenarios
-- RED method patterns (Rate, Errors, Duration)
-- USE method patterns (Utilization, Saturation, Errors)
-- Alerting and recording rule patterns
-- **Read this file when**: implementing standard monitoring patterns like error rates, latency, or resource usage
-
-**best_practices.md**
-- PromQL best practices and anti-patterns
-- Performance optimization guidelines
-- Cardinality management
-- Query structure recommendations
-- **Read this file when**: optimizing queries, reviewing for anti-patterns, or when cardinality concerns arise
-
-**metric_types.md**
-- Detailed guide to Prometheus metric types
-- Counter, Gauge, Histogram, Summary
-- When to use each type
-- Appropriate functions for each type
-- **Read this file when**: clarifying metric type questions or determining appropriate functions for a metric
-
-### examples/
-
-**common_queries.promql**
-- Collection of commonly-used PromQL queries
-- Request rate, error rate, latency queries
-- Resource usage queries
-- Availability and uptime queries
-- Can be copied and customized
-
-**red_method.promql**
-- Complete RED method implementation
-- Request rate queries
-- Error rate queries
-- Duration/latency queries
-
-**use_method.promql**
-- Complete USE method implementation
-- Utilization queries
-- Saturation queries
-- Error queries
-
-**alerting_rules.yaml**
-- Example Prometheus alerting rules
-- Various threshold-based alerts
-- Best practices for alert expressions
-
-**recording_rules.yaml**
-- Example Prometheus recording rules
-- Pre-aggregated metrics
-- Naming conventions
-
-**slo_patterns.promql**
-- SLO, error budget, and burn rate queries
-- Multi-window, multi-burn-rate alerting patterns
-- Latency SLO compliance queries
-
-**kubernetes_patterns.promql**
-- Kubernetes monitoring patterns
-- kube-state-metrics queries (pods, deployments, nodes)
-- cAdvisor container metrics (CPU, memory)
-- Vector matching and joins for Kubernetes
-
-## Important Notes
-
-1. **Always Plan Interactively**: Never generate a query without confirming the plan with the user
-2. **Use AskUserQuestion**: Leverage the tool to gather requirements and confirm plans
-3. **Validate Everything**: Always invoke devops-skills:promql-validator after generation
-4. **Educate Users**: Explain what the query does and why it's structured that way
-5. **Consider Use Case**: Tailor the query based on whether it's for dashboards, alerts, or analysis
-6. **Think About Performance**: Always include label filters and consider cardinality
-7. **Follow Metric Types**: Use appropriate functions for counters, gauges, and histograms
-8. **Format for Readability**: Use multi-line formatting for complex queries
-
-## Success Criteria
-
-A successful query generation session should meet these measurable checkpoints:
-1. Requirement capture completed: goal/use-case/metric/time-range/aggregation recorded.
-2. Plan confirmation completed: user approved plan OR explicit assumption set documented.
-3. Reference decision recorded: `consulted` with file names OR `skipped (trivial case)` with reason.
-4. Query validity completed: syntax passes validator or manual fallback check.
-5. Semantic sanity completed: function choice matches metric type (counter/gauge/histogram/summary).
-6. Cardinality guard completed: query includes explicit filters or aggregation rationale.
-7. Delivery completed: final query + interpretation + next-step customization guidance provided.
-
-## Remember
-
-The goal is to **collaboratively plan** and generate PromQL queries that exactly match user intentions. Always prioritize clarity, correctness, and performance. The interactive planning phase is the most important part of this skill—never skip it!
+### Delivery
+
+Final response includes:
+1. The validated query.
+2. Plain-English meaning + expected value range.
+3. How to use it: dashboard panel, alerting rule (`for:` clause), recording rule, ad-hoc browser.
+4. Customization knobs the user is most likely to tune (window, threshold, label filters).
+
+## Decision tree (metric type → function)
+
+| Metric type | Identifier | Use |
+|---|---|---|
+| Counter | `_total` suffix; monotonically increasing | `rate()`, `irate()`, `increase()` |
+| Gauge | no suffix; can go up or down | direct, `avg_over_time()`, `max_over_time()`, `deriv()` |
+| Classic histogram | `_bucket` + `le` label | `histogram_quantile(q, sum by (le, …) (rate(…_bucket[…])))` |
+| Native histogram | no `_bucket`, no `le` | `histogram_quantile(q, sum by (…) (rate(metric[…])))` |
+| Summary | `{quantile="…"}` | use quantile labels directly; never average them |
+
+Anti-patterns to avoid (full list in `references/best_practices.md`): no label filters, regex when exact match suffices, `rate()` on gauges, missing `rate()` on histogram buckets, missing `le` in aggregation, averaging summary quantiles, joining on high-cardinality labels.
+
+## Common issues
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Empty result | metric not scraped, label typo, range too short | check `up{job="…"}`, verify label values, widen range |
+| Too many series | high-cardinality label, no filters | add label filters, aggregate, or pre-record |
+| Wrong values | wrong function for type (e.g. `rate` on gauge) | match function to metric type per decision tree |
+| Slow query | long range, expensive subquery, regex | shrink range, use recording rule, prefer exact match |
+| Quantile spikes implausibly high | missing `le` in aggregation, or histogram has too few buckets in that range | add `le` to `sum by (…)`, check bucket configuration |
+
+## References and examples
+
+References (read on demand):
+- `references/promql_functions.md` — every function, grouped by category; includes native-histogram functions, subqueries, `@` modifier.
+- `references/promql_patterns.md` — RED / USE / availability / saturation / vector-matching / Kubernetes joins / `offset` / `group_left` / `unless`.
+- `references/metric_types.md` — Counter / Gauge / Histogram (classic + native + NHCB) / Summary; choosing a type.
+- `references/best_practices.md` — cardinality, optimization, anti-pattern catalog, recording-rule naming.
+
+Examples (copy-and-adapt):
+- `examples/common_queries.promql` — request rate, error rate, latency.
+- `examples/red_method.promql` — full RED implementation.
+- `examples/use_method.promql` — full USE implementation.
+- `examples/slo_patterns.promql` — error budget, burn rate, multi-window multi-burn-rate alerts, latency SLO compliance.
+- `examples/alerting_rules.yaml` — production-shaped alerting rules with `for:` clauses.
+- `examples/recording_rules.yaml` — recording rules with `level:metric:operations` naming.
+- `examples/kubernetes_patterns.promql` — kube-state-metrics + cAdvisor patterns and joins.
+
+## Documentation lookup
+
+For features, operators, or behavior you are not sure about:
+
+1. Prefer Context7:
+   - `Context7:resolve-library-id` with `prometheus`
+   - `Context7:query-docs` with the resolved id, topic = the function/operator name
+2. Fallback: WebSearch with `Prometheus PromQL <feature> documentation examples`.
+
+## Integration with sibling skills
+
+- `devops-skills:promql-validator` — call after generation. This skill defers all syntax/anti-pattern checks to the validator.
+- For "review my existing query" / "what's wrong with this" requests, hand off to the validator directly rather than regenerating.

--- a/devops-skills-plugin/skills/promql-generator/references/metric_types.md
+++ b/devops-skills-plugin/skills/promql-generator/references/metric_types.md
@@ -418,6 +418,73 @@ Choose buckets that cover your expected range:
 // 100B, 1KB, 10KB, 100KB, 1MB, 10MB
 ```
 
+### Native vs Classic Histograms
+
+Native histograms are stable in Prometheus 3.x and offer significant advantages over classic histograms:
+- Sparse bucket representation with near-zero cost for empty buckets
+- No configuration of bucket boundaries during instrumentation
+- Coverage of the full float64 range
+- Efficient mergeability across histograms
+- Simpler query syntax (no `_bucket` suffix or `le` label)
+
+```promql
+# Classic histogram (requires _bucket suffix and le label)
+histogram_quantile(0.95,
+  sum by (job, le) (rate(http_request_duration_seconds_bucket[5m]))
+)
+
+# Native histogram (simpler - no _bucket suffix, no le label needed)
+histogram_quantile(0.95,
+  sum by (job) (rate(http_request_duration_seconds[5m]))
+)
+```
+
+For function-level reference (histogram_quantile, histogram_count, histogram_sum, histogram_fraction, histogram_stddev, histogram_avg) see references/promql_functions.md.
+
+### Detecting Native vs Classic Histograms
+
+Native histograms are identified by:
+- No `_bucket` suffix on the metric name
+- No `le` label in the time series
+- The metric stores histogram data directly (not separate bucket counters)
+
+Enable native-histogram scraping per job:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'my-app'
+    scrape_native_histograms: true
+```
+
+### Custom Bucket Native Histograms (NHCB)
+
+Prometheus 3.4+ supports custom bucket native histograms (schema -53), allowing classic-to-native histogram conversion at scrape time. Key migration path for users with existing classic histograms.
+
+Benefits:
+- Keep existing instrumentation (no code changes needed)
+- Store classic histograms as native histograms for lower storage cost
+- Query with native histogram syntax
+- Improved reliability and compression
+
+```yaml
+# prometheus.yml - convert classic histograms to NHCB on scrape (Prometheus 3.4+)
+global:
+  scrape_configs:
+    - job_name: 'my-app'
+      convert_classic_histograms_to_nhcb: true
+```
+
+```promql
+# Query NHCB metrics the same way as native histograms
+histogram_quantile(0.95, sum by (job) (rate(http_request_duration_seconds[5m])))
+
+# histogram_fraction also works with NHCB (Prometheus 3.4+)
+histogram_fraction(0, 0.2, rate(http_request_duration_seconds[5m]))
+```
+
+Schema -53 indicates custom bucket boundaries. Histograms with different custom bucket boundaries are generally not mergeable with each other.
+
 ---
 
 ## Summary
@@ -624,3 +691,9 @@ node_network_receive_bytes_total   # namespace: node, subsystem: network
 - [Prometheus Metric Types](https://prometheus.io/docs/concepts/metric_types/)
 - [Prometheus Best Practices - Naming](https://prometheus.io/docs/practices/naming/)
 - [Histograms and Summaries](https://prometheus.io/docs/practices/histograms/)
+
+---
+
+## Version notes (verify before use)
+
+Captured 2026-04: native histograms became stable in Prometheus 3.0 (released November 2024). Starting with Prometheus v3.8.0 they are fully stable; scraping native histograms still requires explicit activation via the `scrape_native_histograms` configuration setting. From v3.9, no feature flag is needed but `scrape_native_histograms` must be set explicitly. Verify the current Prometheus release notes before relying on these specifics.

--- a/devops-skills-plugin/skills/promql-generator/references/promql_functions.md
+++ b/devops-skills-plugin/skills/promql-generator/references/promql_functions.md
@@ -1145,6 +1145,51 @@ max_over_time(
 ) * 100
 ```
 
+## Subqueries
+
+Subqueries evaluate an instant query repeatedly over a range, then expose the result as a range vector for an outer aggregator. Useful for combining range-vector functions (e.g. apply `rate()` then `max_over_time` over the rates).
+
+Syntax: `<instant_query>[<range>:<resolution>]`
+
+- `<range>`: time window over which to evaluate
+- `<resolution>`: step between evaluations (defaults to global evaluation interval if omitted)
+
+```promql
+# Maximum 5-minute rate observed over the past 30 minutes (sampled every 1 minute)
+max_over_time(
+  rate(http_requests_total[5m])[30m:1m]
+)
+
+# 95th percentile of per-minute error rates over the past hour
+quantile_over_time(0.95,
+  rate(http_errors_total[1m])[1h:1m]
+)
+```
+
+Subqueries are expensive — prefer recording rules when the inner expression is reused.
+
+## `@` Modifier
+
+The `@` modifier evaluates a selector at a specific timestamp instead of the query's current evaluation time. Useful for anchoring a comparison against a known point or against the query end.
+
+```promql
+# Evaluate rate at the end of a range query window
+rate(http_requests_total[5m] @ end())
+
+# Evaluate rate at the start of the range query window
+rate(http_requests_total[5m] @ start())
+
+# Evaluate at a specific Unix timestamp
+rate(http_requests_total[5m] @ 1609459200)
+
+# Compare current rate vs rate at a fixed timestamp
+rate(http_requests_total[5m])
+  /
+rate(http_requests_total[5m] @ 1609459200)
+```
+
+Combine `@` with `offset` for fully explicit time anchoring; `@` fixes the absolute moment, `offset` shifts relative to it.
+
 ## Performance Considerations
 
 1. **Range Vector Size**: Larger ranges process more data

--- a/devops-skills-plugin/skills/terraform-generator/SKILL.md
+++ b/devops-skills-plugin/skills/terraform-generator/SKILL.md
@@ -1,107 +1,107 @@
 ---
 name: terraform-generator
-description: Create, generate, write, or scaffold Terraform .tf HCL — resources, modules, providers, variables, outputs.
+description: Generate production-ready Terraform HCL — resources, modules, providers, variables, outputs. Use when the user asks to create, scaffold, write, or build Terraform configuration / .tf files / IaC for AWS, Azure, GCP, Kubernetes, or third-party providers. Triggers "write terraform for…", "scaffold a TF module", "create infra as code", "generate .tf", "set up a VPC in Terraform". Not for reviewing or debugging existing Terraform — see terraform-validator.
 ---
 
 # Terraform Generator
 
 ## Overview
 
-This skill enables the generation of production-ready Terraform configurations following best practices and current standards. Automatically integrates validation and documentation lookup for custom providers and modules.
+Generate production-ready Terraform configurations following current standards. Integrates validation and documentation lookup for custom providers and modules.
 
-## Critical Requirements Checklist
+## When to Use This Skill
 
-**STOP: You MUST complete ALL steps in order. Do NOT skip any REQUIRED step.**
+| Use terraform-generator | Use OTHER skill |
+|-------------------------|-----------------|
+| Create new .tf files / modules | **terraform-validator**: Validate, lint, or scan existing Terraform |
+| Scaffold IaC for AWS/Azure/GCP/Kubernetes | **terragrunt-generator**: Generate Terragrunt wrappers |
+| Add resources, variables, outputs to a fresh project | **k8s-yaml-generator**: Raw Kubernetes manifests (no Terraform) |
+| Convert architecture into HCL | **helm-generator**: Helm charts |
 
-| Step | Action | Required |
-|------|--------|----------|
-| 1 | Understand requirements (providers, resources, modules) | ✅ REQUIRED |
-| 2 | Check for custom providers/modules and lookup documentation | ✅ REQUIRED |
-| 3 | Consult reference files before generation | ✅ REQUIRED |
-| 4 | Generate Terraform files with ALL best practices | ✅ REQUIRED |
-| 5 | Include data sources for dynamic values (region, account, AMIs) | ✅ REQUIRED |
-| 6 | Add lifecycle rules on critical resources (KMS, databases) | ✅ REQUIRED |
-| 7 | Invoke `Skill(devops-skills:terraform-validator)` | ✅ REQUIRED |
-| 8 | **FIX all validation/security failures and RE-VALIDATE** | ✅ REQUIRED |
-| 9 | Provide usage instructions (files, next steps, security) | ✅ REQUIRED |
+### Trigger Phrases
 
-> **IMPORTANT:** If validation fails (terraform validate OR security scan), you MUST fix the issues and re-run validation until ALL checks pass. Do NOT proceed to Step 9 with failing checks.
+- "write terraform for …"
+- "scaffold a TF module"
+- "create infra as code"
+- "generate .tf for …"
+- "set up a VPC in Terraform"
+- "build IaC for …"
 
-## Core Workflow
+### Non-triggers
 
-When generating Terraform configurations, follow this workflow:
+- "validate this terraform" / "lint .tf" / "fix terraform errors" — invoke `Skill(devops-skills:terraform-validator)`.
+- "review my terraform plan output" — invoke `Skill(devops-skills:terraform-validator)`.
+
+## Prerequisites
+
+For the generation workflow itself, no tooling is required. The CI checks and validation loop need:
+
+- `terraform` 1.8+ on PATH (used by `scripts/run_ci_checks.sh` for `terraform fmt -check`; install from https://developer.hashicorp.com/terraform/install)
+- `shellcheck` (optional; the CI script gates on it when `STRICT_SHELLCHECK=true`; install via `apt install shellcheck` / `brew install shellcheck`)
+- `bash` 4+ (for the CI script)
+
+If `terraform` is missing, `scripts/run_ci_checks.sh` skips the fmt step and emits `SKIP (terraform not installed)` — install before running CI gates.
+
+## Generation Workflow
+
+| Step | Action |
+|------|--------|
+| 1 | Understand requirements (providers, resources, modules, version constraints) |
+| 2 | If custom/third-party providers or modules are involved, look up version-specific docs |
+| 3 | Consult reference files (see matrix below) |
+| 4 | Generate `.tf` files following the patterns in this doc and `references/` |
+| 5 | Include data sources for dynamic values (region, account, AMIs) |
+| 6 | Add lifecycle rules on critical/stateful resources |
+| 7 | Invoke `Skill(devops-skills:terraform-validator)` |
+| 8 | Fix any validation/security failures and re-validate until clean |
+| 9 | Provide usage instructions (files generated, init/plan/apply, security reminders) |
+
+If validation fails (terraform validate or security scan), fix the issues and re-run validation until all checks pass before moving to Step 9.
 
 ### Step 1: Understand Requirements
 
-Analyze the user's request to determine:
-- What infrastructure resources need to be created
-- Which Terraform providers are required (AWS, Azure, GCP, custom, etc.)
-- Whether any modules are being used (official, community, or custom)
-- Version constraints for providers and modules
-- Variable inputs and outputs needed
-- State backend configuration (local, S3, remote, etc.)
+Determine:
+- Which infrastructure resources to create
+- Which providers are required (AWS, Azure, GCP, Kubernetes, custom)
+- Whether modules are involved (official, community, private)
+- Version constraints
+- Variable inputs and outputs
+- Backend configuration (local, S3, remote)
 
 ### Step 2: Check for Custom Providers/Modules
 
-Before generating configurations, identify if custom or third-party providers/modules are involved:
+**Standard providers** (no lookup needed): hashicorp/aws, hashicorp/azurerm, hashicorp/google, hashicorp/kubernetes, other official HashiCorp providers.
 
-**Standard providers** (no lookup needed):
-- hashicorp/aws
-- hashicorp/azurerm
-- hashicorp/google
-- hashicorp/kubernetes
-- Other official HashiCorp providers
+**Custom/third-party** (require documentation lookup): datadog/datadog, mongodb/mongodbatlas, terraform-aws-modules/*, private/company modules, community modules.
 
-**Custom/third-party providers/modules** (require documentation lookup):
-- Third-party providers (e.g., datadog/datadog, mongodb/mongodbatlas)
-- Custom modules from Terraform Registry
-- Private or company-specific modules
-- Community modules
+When custom providers or modules are detected:
 
-**When custom providers/modules are detected:**
+1. Use WebSearch with the format: `"<provider/module> terraform <version> documentation <resource>"` (e.g. `"datadog terraform provider v3.30 monitor resource documentation"`).
+2. Focus on registry.terraform.io, official provider docs, required/optional arguments, attribute references, examples, and version compatibility notes.
+3. If Context7 MCP is available, prefer `Context7:resolve-library-id` -> `Context7:query-docs`.
 
-1. Use WebSearch to find version-specific documentation:
-   ```
-   Search query format: "[provider/module name] terraform [version] documentation [specific resource]"
-   Example: "datadog terraform provider v3.30 monitor resource documentation"
-   Example: "terraform-aws-modules vpc version 5.0 documentation"
-   ```
+### Step 3: Consult Reference Files
 
-2. Focus searches on:
-   - Official documentation (registry.terraform.io, provider websites)
-   - Required and optional arguments
-   - Attribute references
-   - Example usage
-   - Version compatibility notes
+| Reference | When to read |
+|-----------|--------------|
+| `references/terraform_best_practices.md` | Always — baseline patterns |
+| `references/provider_examples.md` | Any AWS, Azure, GCP, or Kubernetes resource |
+| `references/common_patterns.md` | Multi-environment, workspace, composition, DR, conditional patterns |
+| `references/modern_features.md` | Provider-defined functions, ephemeral, write-only, actions, query, version decisions |
 
-3. If Context7 MCP is available and the provider/module is supported, use it as an alternative:
-   ```
-   mcp__context7__resolve-library-id → mcp__context7__query-docs
-   ```
-
-### Step 2.5: Consult Reference Files (REQUIRED)
-
-Before generating configuration, you MUST consult reference files using this matrix:
-
-| Reference | Requirement | Read When |
-|-----------|-------------|-----------|
-| `terraform_best_practices.md` | REQUIRED | Always - contains baseline required patterns |
-| `provider_examples.md` | REQUIRED | Any AWS, Azure, GCP, or Kubernetes resource generation |
-| `common_patterns.md` | OPTIONAL by default, REQUIRED for complex requests | Multi-environment, workspace, composition, DR, or conditional patterns |
-
-Open references by path:
+Open by path:
 
 ```
 devops-skills-plugin/skills/terraform-generator/references/terraform_best_practices.md
 devops-skills-plugin/skills/terraform-generator/references/provider_examples.md
 devops-skills-plugin/skills/terraform-generator/references/common_patterns.md
+devops-skills-plugin/skills/terraform-generator/references/modern_features.md
 ```
 
-### Step 3: Generate Terraform Configuration
+### Step 4: Generate Terraform Configuration
 
-Generate HCL files following best practices:
+**File organization:**
 
-**File Organization:**
 ```
 terraform-project/
 ├── main.tf           # Primary resource definitions
@@ -112,149 +112,113 @@ terraform-project/
 └── backend.tf        # Backend configuration (optional)
 ```
 
-**Best Practices to Follow:**
+**Provider configuration:**
 
-1. **Provider Configuration:**
-   ```hcl
-   terraform {
-     required_version = ">= 1.10, < 2.0"
+```hcl
+terraform {
+  required_version = ">= 1.10, < 2.0"
 
-     required_providers {
-       aws = {
-         source  = "hashicorp/aws"
-         version = "~> 6.0"  # Major pin; verify exact current version when needed
-       }
-     }
-   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"  # Major pin; verify exact current version when needed
+    }
+  }
+}
 
-   provider "aws" {
-     region = var.aws_region
-   }
-   ```
+provider "aws" {
+  region = var.aws_region
+}
+```
 
-2. **Resource Naming:**
-   - Use descriptive resource names
-   - Follow snake_case convention
-   - Include resource type in name when helpful
-   ```hcl
-   resource "aws_instance" "web_server" {
-     # ...
-   }
-   ```
+**Resource naming:** descriptive, snake_case, include resource type when helpful.
 
-3. **Variable Declarations:**
-   ```hcl
-   variable "instance_type" {
-     description = "EC2 instance type for web servers"
-     type        = string
-     default     = "t3.micro"
+```hcl
+resource "aws_instance" "web_server" {
+  # ...
+}
+```
 
-     validation {
-       condition     = contains(["t3.micro", "t3.small", "t3.medium"], var.instance_type)
-       error_message = "Instance type must be t3.micro, t3.small, or t3.medium."
-     }
-   }
-   ```
+**Variables with validation:**
 
-4. **Output Values:**
-   ```hcl
-   output "instance_public_ip" {
-     description = "Public IP address of the web server"
-     value       = aws_instance.web_server.public_ip
-   }
-   ```
+```hcl
+variable "instance_type" {
+  description = "EC2 instance type for web servers"
+  type        = string
+  default     = "t3.micro"
 
-5. **Use Data Sources for References:**
-   ```hcl
-   data "aws_ami" "ubuntu" {
-     most_recent = true
-     owners      = ["099720109477"] # Canonical
+  validation {
+    condition     = contains(["t3.micro", "t3.small", "t3.medium"], var.instance_type)
+    error_message = "Instance type must be t3.micro, t3.small, or t3.medium."
+  }
+}
+```
 
-     filter {
-       name   = "name"
-       values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
-     }
-   }
-   ```
+**Outputs:**
 
-6. **Module Usage:**
-   ```hcl
-   module "vpc" {
-     source  = "terraform-aws-modules/vpc/aws"
-     version = "5.0.0"
+```hcl
+output "instance_public_ip" {
+  description = "Public IP address of the web server"
+  value       = aws_instance.web_server.public_ip
+}
+```
 
-     name = "my-vpc"
-     cidr = "10.0.0.0/16"
+**Locals for computed values:**
 
-     azs             = ["us-east-1a", "us-east-1b"]
-     private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
-     public_subnets  = ["10.0.101.0/24", "10.0.102.0/24"]
-   }
-   ```
+```hcl
+locals {
+  common_tags = {
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+    Project     = var.project_name
+  }
+}
+```
 
-7. **Use locals for Computed Values:**
-   ```hcl
-   locals {
-     common_tags = {
-       Environment = var.environment
-       ManagedBy   = "Terraform"
-       Project     = var.project_name
-     }
-   }
-   ```
+**Module usage** (always pin versions):
 
-8. **Lifecycle Rules When Appropriate:**
-   ```hcl
-   resource "aws_instance" "example" {
-     # ...
+```hcl
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
 
-     lifecycle {
-       create_before_destroy = true
-       prevent_destroy       = true
-       ignore_changes        = [tags]
-     }
-   }
-   ```
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
 
-9. **Dynamic Blocks for Repeated Configuration:**
-   ```hcl
-   resource "aws_security_group" "example" {
-     # ...
+  azs             = ["us-east-1a", "us-east-1b"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+```
 
-     dynamic "ingress" {
-       for_each = var.ingress_rules
-       content {
-         from_port   = ingress.value.from_port
-         to_port     = ingress.value.to_port
-         protocol    = ingress.value.protocol
-         cidr_blocks = ingress.value.cidr_blocks
-       }
-     }
-   }
-   ```
+**Dynamic blocks for repeated configuration:**
 
-10. **Comments and Documentation:**
-    - Add comments explaining complex logic
-    - Document why certain values are used
-    - Include examples in variable descriptions
+```hcl
+resource "aws_security_group" "example" {
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+}
+```
 
-**Security Best Practices:**
-- Never hardcode sensitive values (use variables)
-- Use data sources for AMIs and other dynamic values
-- Implement least-privilege IAM policies
-- Enable encryption by default
-- Use secure backend configurations
+**Security baseline:** never hardcode sensitive values, use data sources for AMIs and dynamic IDs, implement least-privilege IAM, enable encryption by default, use secure backends.
 
-### Required: Data Sources for Dynamic Values (Provider-Aware)
+### Data Sources for Dynamic Values (provider-aware)
 
-You MUST include provider-appropriate data lookups for dynamic infrastructure values. Do NOT hardcode cloud/account/region/image IDs.
+Include provider-appropriate data lookups for dynamic infrastructure values. Do not hardcode cloud/account/region/image IDs (why: prevents env drift and makes modules reusable across accounts/regions).
 
 | Provider | Required Dynamic Context | Typical Data Sources |
 |----------|--------------------------|----------------------|
 | AWS | Region/account/AZ/image IDs | `aws_region`, `aws_caller_identity`, `aws_availability_zones`, `aws_ami` |
 | Azure | Tenant/subscription/client context | `azurerm_client_config`, `azurerm_subscription` |
 | GCP | Project/client context/zone discovery | `google_client_config`, `google_compute_zones`, `google_compute_image` |
-| Kubernetes | Cluster endpoint/auth from trusted source | Use module outputs or cloud data sources; avoid hardcoded tokens/endpoints |
+| Kubernetes | Cluster endpoint/auth from trusted source | Module outputs or cloud data sources; avoid hardcoded tokens/endpoints |
 
 ```hcl
 # AWS dynamic context
@@ -269,16 +233,16 @@ data "azurerm_subscription" "current" {}
 data "google_client_config" "current" {}
 ```
 
-### Required: Lifecycle and Deletion Safeguards (Provider-Aware)
+### Lifecycle and Deletion Safeguards (provider-aware)
 
-You MUST protect stateful and critical resources from accidental destruction/deletion using both Terraform lifecycle and provider-native safeguards.
+For stateful and critical resources, you MUST set `lifecycle { prevent_destroy = true }` and the provider-native deletion-protection attribute (why: a stray `terraform destroy` against the wrong workspace can permanently delete production data; both gates are needed because `prevent_destroy` blocks Terraform deletion only, while service-level flags block out-of-band deletion).
 
 | Provider | Critical Resource Classes | Required Protection Mechanism |
 |----------|---------------------------|-------------------------------|
-| AWS | KMS, RDS, S3 data buckets, DynamoDB, ElastiCache, secrets | `lifecycle { prevent_destroy = true }` and service-specific deletion protection where supported |
-| Azure | Key Vaults, SQL, Storage, stateful compute | `prevent_destroy` where appropriate plus provider feature flags/resource deletion protection |
-| GCP | Cloud SQL, GKE, storage, stateful compute | `prevent_destroy` and resource-level `deletion_protection = true` where supported |
-| Kubernetes | Stateful workloads and persistent data | Avoid destructive replacement patterns and protect backing cloud resources |
+| AWS | KMS, RDS, S3 data buckets, DynamoDB, ElastiCache, secrets | `lifecycle { prevent_destroy = true }` + service-specific deletion protection |
+| Azure | Key Vaults, SQL, Storage, stateful compute | `prevent_destroy` + provider feature flags / resource deletion protection |
+| GCP | Cloud SQL, GKE, storage, stateful compute | `prevent_destroy` + `deletion_protection = true` where supported |
+| Kubernetes | Stateful workloads and persistent data | Avoid destructive replacement patterns; protect backing cloud resources |
 
 ```hcl
 resource "aws_db_instance" "main" {
@@ -295,20 +259,20 @@ resource "google_sql_database_instance" "main" {
 }
 ```
 
-### Required: Object Storage Lifecycle Safeguards
+Before removing `prevent_destroy` or bumping `password_wo_version` (which rotates a database/secret), STOP and confirm with the user — both are destructive operations whose blast radius is not visible in the plan diff alone.
 
-When using AWS S3 lifecycle configuration, ALWAYS include a rule to abort incomplete multipart uploads:
+### Object Storage Lifecycle Safeguards
+
+For AWS S3 lifecycle configuration you MUST include a rule to abort incomplete multipart uploads (why: orphaned parts accrue storage cost indefinitely and Checkov `CKV_AWS_300` enforces this).
 
 ```hcl
 resource "aws_s3_bucket_lifecycle_configuration" "main" {
   bucket = aws_s3_bucket.main.id
 
-  # REQUIRED: Abort incomplete multipart uploads to prevent storage costs
   rule {
     id     = "abort-incomplete-uploads"
     status = "Enabled"
 
-    # Filter applies to all objects (empty filter = all objects)
     filter {}
 
     abort_incomplete_multipart_upload {
@@ -316,13 +280,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "main" {
     }
   }
 
-  # Other lifecycle rules (e.g., transition to IA)
   rule {
     id     = "transition-to-ia"
     status = "Enabled"
 
     filter {
-      prefix = ""  # Apply to all objects
+      prefix = ""
     }
 
     transition {
@@ -342,65 +305,34 @@ resource "aws_s3_bucket_lifecycle_configuration" "main" {
 }
 ```
 
-> **Why?** Incomplete multipart uploads consume storage and incur costs. Checkov check `CKV_AWS_300` enforces this for AWS.
->
-> For Azure/GCP object storage, add equivalent lifecycle/retention rules for stale objects and old versions.
+For Azure / GCP object storage, add equivalent lifecycle/retention rules for stale objects and old versions.
 
-### Step 4: Validate Generated Configuration (REQUIRED)
+### Step 5: Validate Generated Configuration
 
-After generating Terraform files, ALWAYS validate them using the devops-skills:terraform-validator skill:
+After generating files, invoke:
 
 ```
-Invoke: Skill(devops-skills:terraform-validator)
+Skill(devops-skills:terraform-validator)
 ```
 
-The devops-skills:terraform-validator skill will:
-1. Check HCL syntax with `terraform fmt -check`
-2. Initialize the configuration with `terraform init`
-3. Validate the configuration with `terraform validate`
-4. Run security scan with Checkov
-5. Perform dry-run testing (if requested) with `terraform plan`
+The validator runs `terraform fmt -check`, `terraform init`, `terraform validate`, and Checkov; on request it also runs `terraform plan`.
 
-**CRITICAL: Fix-and-Revalidate Loop**
+**Fix-and-revalidate loop:** if any check fails, review the error, edit the file to resolve it, re-invoke the validator, and repeat until all checks pass. Do not move to Step 6 with failing checks.
 
-If ANY validation or security check fails, you MUST:
+Common validation failures:
 
-1. **Review the error** - Understand what failed and why
-2. **Fix the issue** - Edit the generated file to resolve the problem
-3. **Re-run validation** - Invoke `Skill(devops-skills:terraform-validator)` again
-4. **Repeat until ALL checks pass** - Do NOT proceed with failing checks
-
-```
-┌─────────────────────────────────────────────────────────┐
-│  VALIDATION FAILED?                                      │
-│                                                          │
-│  ┌─────────┐    ┌─────────┐    ┌─────────────────────┐  │
-│  │  Fix    │───▶│ Re-run  │───▶│ All checks pass?    │  │
-│  │  Issue  │    │ Skill   │    │ YES → Step 5        │  │
-│  └─────────┘    └─────────┘    │ NO  → Loop back     │  │
-│       ▲                         └─────────────────────┘  │
-│       │                                    │             │
-│       └────────────────────────────────────┘             │
-└─────────────────────────────────────────────────────────┘
-```
-
-**Common validation failures to fix:**
 | Check | Issue | Fix |
 |-------|-------|-----|
 | `CKV_AWS_300` | Missing abort multipart upload | Add `abort_incomplete_multipart_upload` rule |
 | `CKV_AWS_24` | SSH open to 0.0.0.0/0 | Restrict to specific CIDR |
 | `CKV_AWS_16` | RDS encryption disabled | Add `storage_encrypted = true` |
-| `terraform validate` | Invalid resource argument | Check provider documentation |
+| `terraform validate` | Invalid resource argument | Check provider docs (Context7 / WebSearch) |
 
-**If custom providers are detected during validation:**
-- The devops-skills:terraform-validator skill will automatically fetch documentation
-- Use the fetched documentation to fix any issues
+If custom providers are detected during validation, the validator skill fetches docs automatically — use those to fix issues.
 
-### Step 5: Provide Usage Instructions (REQUIRED)
+### Step 6: Provide Usage Instructions
 
-After successful generation and validation with ALL checks passing, you MUST provide the user with:
-
-**Required Output Format:**
+After all checks pass, deliver:
 
 ```markdown
 ## Generated Files
@@ -409,23 +341,14 @@ After successful generation and validation with ALL checks passing, you MUST pro
 |------|-------------|
 | `<actual-file-path>` | What was generated in that file |
 
-Only list files that were actually generated for this request. Do not include placeholder paths or files that do not exist.
+(List only files actually generated; no placeholders.)
 
 ## Next Steps
 
 1. Review and customize `terraform.tfvars` with your values
-2. Initialize Terraform:
-   ```bash
-   terraform init
-   ```
-3. Review the execution plan:
-   ```bash
-   terraform plan
-   ```
-4. Apply the configuration:
-   ```bash
-   terraform apply
-   ```
+2. Initialize Terraform: `terraform init`
+3. Review the execution plan: `terraform plan`
+4. Apply the configuration: `terraform apply`
 
 ## Customization Notes
 
@@ -435,138 +358,53 @@ Only list files that were actually generated for this request. Do not include pl
 
 ## Security Reminders
 
-⚠️ Before applying:
+Before applying:
 - Review IAM policies and permissions
 - Ensure sensitive values are NOT committed to version control
 - Configure state backend with encryption enabled
 - Set up state locking for team collaboration
 ```
 
-> **IMPORTANT:** Do NOT skip Step 5. The user needs actionable guidance on how to use the generated configuration.
-
 ## Common Generation Patterns
 
-### Pattern 1: Simple Resource Creation
-
-User request: "Create an AWS S3 bucket with versioning"
-
-Generated files:
-- `main.tf` - S3 bucket resource with versioning enabled
-- `variables.tf` - Bucket name, tags variables
-- `outputs.tf` - Bucket ARN and name outputs
-- `versions.tf` - AWS provider version constraints
-
-### Pattern 2: Module-Based Infrastructure
-
-User request: "Set up a VPC using the official AWS VPC module"
-
-Actions:
-1. Identify module: terraform-aws-modules/vpc/aws
-2. Web search for latest version and documentation
-3. Generate configuration using module with appropriate inputs
-4. Validate with devops-skills:terraform-validator
-
-### Pattern 3: Multi-Provider Configuration
-
-User request: "Create infrastructure across AWS and Datadog"
-
-Actions:
-1. Identify standard provider (AWS) and custom provider (Datadog)
-2. Web search for Datadog provider documentation with version
-3. Generate configuration with both providers properly configured
-4. Ensure provider aliases if needed
-5. Validate with devops-skills:terraform-validator
-
-### Pattern 4: Complex Resource with Dependencies
-
-User request: "Create an ECS cluster with ALB and auto-scaling"
-
-Generated structure:
-- Multiple resource blocks with proper dependencies
-- Data sources for AMIs, availability zones, etc.
-- Local values for computed configurations
-- Comprehensive variables and outputs
-- Proper dependency management using implicit references
+See `references/common_patterns.md` for worked examples (multi-environment, workspace, blue-green, data layer, module composition, conditional, service mesh, tagging, secret injection, auto-scaling, DR, cost optimization).
 
 ## Error Handling
 
-**Common Issues and Solutions:**
-
-1. **Provider Not Found:**
-   - Ensure provider is listed in `required_providers` block
-   - Verify source address format: `namespace/name`
-   - Check version constraint syntax
-
-2. **Invalid Resource Arguments:**
-   - Refer to web search results for custom providers
-   - Check for required vs optional arguments
-   - Verify attribute value types (string, number, bool, list, map)
-
-3. **Circular Dependencies:**
-   - Review resource references
-   - Use `depends_on` explicit dependencies if needed
-   - Consider breaking into separate modules
-
-4. **Validation Failures:**
-   - Run devops-skills:terraform-validator skill to get detailed errors
-   - Fix issues one at a time
-   - Re-validate after each fix
+1. **Provider not found:** ensure provider is in `required_providers`, verify `namespace/name`, check version constraint syntax.
+2. **Invalid resource arguments:** consult provider docs (Context7 / WebSearch); check required vs optional; verify value types.
+3. **Circular dependencies:** review references; use `depends_on` only when implicit refs cannot express the relation; consider splitting into modules.
+4. **Validation failures:** invoke terraform-validator for detailed errors; fix one at a time; re-validate after each fix.
 
 ## Version Awareness
 
-Always consider version compatibility:
+### Required Version Decision Rule
 
-1. **Terraform Version:**
-   - Use `required_version` constraint with both lower and upper bounds
-   - If generated configuration includes write-only arguments (`*_wo`): use `required_version = ">= 1.11, < 2.0"`.
-   - Else if it uses ephemeral constructs (`ephemeral` blocks, ephemeral variables/outputs) without write-only arguments: use `required_version = ">= 1.10, < 2.0"`.
-   - Else use the project baseline (default `>= 1.8, < 2.0` unless repository policy requires newer).
-   - Use `>= 1.14, < 2.0` for latest features (actions, query command)
-   - Document any version-specific features used (see below)
+Apply this rule whenever emitting a `terraform { required_version = ... }` block:
 
-2. **Provider Version Policy (canonical):**
-   - Pin provider major versions with `~>` constraints (for example `~> 6.0`, `~> 4.0`, `~> 7.0`).
-   - Do not claim "latest" version unless verified online during the current run.
-   - Keep cross-provider guidance consistent:
-     - AWS family: major-pin policy (for example `~> 6.0`)
-     - AzureRM: major-pin policy (for example `~> 4.0`)
-     - Google: major-pin policy (for example `~> 7.0`)
-     - Kubernetes: major/minor pin based on target cluster/provider compatibility
-   - Use the same provider/version language in `SKILL.md`, `references/terraform_best_practices.md`, and template `assets/minimal-project/versions.tf`.
+- If generated configuration includes write-only arguments (`*_wo`): use `required_version = ">= 1.11, < 2.0"`.
+- Else if it uses ephemeral constructs (`ephemeral` blocks, ephemeral variables/outputs) without write-only arguments: use `required_version = ">= 1.10, < 2.0"`.
+- Otherwise: project baseline (default `>= 1.8, < 2.0`); for latest features (actions, query): `>= 1.14, < 2.0`.
 
-3. **Module Versions:**
-   - Always pin module versions
-   - Review module documentation for version compatibility
-   - Test module updates in non-production first
+### Version Feature Matrix (excerpt)
 
-### Required Version Decision Table
+| Feature | Minimum Version |
+|---------|-----------------|
+| Ephemeral resources | 1.10+ |
+| Write-only arguments | 1.11+ |
 
-| Generated Output Contains | Required Version to Emit |
-|---------------------------|--------------------------|
-| Any write-only argument (`*_wo`) | `>= 1.11, < 2.0` |
-| Ephemeral constructs only (no write-only) | `>= 1.10, < 2.0` |
-| Neither write-only nor ephemeral | Project baseline (default `>= 1.8, < 2.0`) |
+See `references/modern_features.md` for the complete feature matrix.
 
-#### Feature-Gating Examples
+### Write-Only Arguments
+
+Write-only arguments (`*_wo`) accept ephemeral values and are never persisted to state. They require Terraform 1.11+ and a `*_wo_version` companion to trigger rotation.
 
 ```hcl
-# Positive: write-only usage requires Terraform 1.11+
 terraform {
   required_version = ">= 1.11, < 2.0"
 }
 
-ephemeral "random_password" "db_password" {
-  length = 16
-}
-
 resource "aws_db_instance" "main" {
-  identifier          = "mydb"
-  instance_class      = "db.t3.micro"
-  allocated_storage   = 20
-  engine              = "postgres"
-  username            = "admin"
-  skip_final_snapshot = true
-
   password_wo         = ephemeral.random_password.db_password.result
   password_wo_version = 1
 }
@@ -583,459 +421,36 @@ resource "aws_db_instance" "invalid" {
 }
 ```
 
-### Terraform Version Feature Matrix
+For full positive examples, see `references/modern_features.md` ("Write-Only Arguments" section).
 
-| Feature | Minimum Version |
-|---------|-----------------|
-| `terraform_data` resource | 1.4+ |
-| `import {}` blocks | 1.5+ |
-| `check {}` blocks | 1.5+ |
-| Native testing (`.tftest.hcl`) | 1.6+ |
-| Test mocking | 1.7+ |
-| `removed {}` blocks | 1.7+ |
-| Provider-defined functions | 1.8+ |
-| Cross-type refactoring | 1.8+ |
-| Enhanced variable validations | 1.9+ |
-| `templatestring` function | 1.9+ |
-| Ephemeral resources | 1.10+ |
-| Write-only arguments | 1.11+ |
-| S3 native state locking | 1.11+ |
-| Import blocks with `for_each` | 1.12+ |
-| Actions block | 1.14+ |
-| List resources (`tfquery.hcl`) | 1.14+ |
-| `terraform query` command | 1.14+ |
+### Provider and Module Versions
 
-## Modern Terraform Features (1.8+)
-
-### Provider-Defined Functions (Terraform 1.8+)
-
-Provider-defined functions extend Terraform's built-in functions with provider-specific logic.
-
-**Syntax:** `provider::<provider_name>::<function_name>(arguments)`
-
-```hcl
-# AWS Provider Functions (v5.40+)
-locals {
-  # Parse an ARN into components
-  parsed_arn = provider::aws::arn_parse(aws_instance.web.arn)
-  account_id = local.parsed_arn.account
-  region     = local.parsed_arn.region
-
-  # Build an ARN from components
-  custom_arn = provider::aws::arn_build({
-    partition = "aws"
-    service   = "s3"
-    region    = ""
-    account   = ""
-    resource  = "my-bucket/my-key"
-  })
-}
-
-# Google Cloud Provider Functions (v5.23+)
-locals {
-  # Extract region from zone
-  region = provider::google::region_from_zone(var.zone)  # "us-west1-a" → "us-west1"
-}
-
-# Kubernetes Provider Functions (v2.28+)
-locals {
-  # Encode HCL to Kubernetes manifest YAML
-  manifest_yaml = provider::kubernetes::manifest_encode(local.deployment_config)
-}
-```
-
-### Ephemeral Resources (Terraform 1.10+)
-
-Ephemeral resources provide temporary values that are **never persisted** in state or plan files. Critical for handling secrets securely.
-
-```hcl
-# Generate a password that never touches state
-ephemeral "random_password" "db_password" {
-  length           = 16
-  special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
-}
-
-# Fetch secrets ephemerally from AWS Secrets Manager
-ephemeral "aws_secretsmanager_secret_version" "api_key" {
-  secret_id = aws_secretsmanager_secret.api_key.id
-}
-
-# Ephemeral variables (declare with ephemeral = true)
-variable "temporary_token" {
-  type      = string
-  ephemeral = true  # Value won't be stored in state
-}
-
-# Ephemeral outputs
-output "session_token" {
-  value     = ephemeral.aws_secretsmanager_secret_version.api_key.secret_string
-  ephemeral = true  # Won't be stored in state
-}
-```
-
-### Write-Only Arguments (Terraform 1.11+)
-
-Write-only arguments accept ephemeral values and are never persisted. They use `_wo` suffix and require a version attribute.
-
-```hcl
-terraform {
-  required_version = ">= 1.11, < 2.0"
-}
-
-# Secure database password handling
-ephemeral "random_password" "db_password" {
-  length = 16
-}
-
-resource "aws_db_instance" "main" {
-  identifier        = "mydb"
-  instance_class    = "db.t3.micro"
-  allocated_storage = 20
-  engine            = "postgres"
-  username          = "admin"
-
-  # Write-only password - never stored in state!
-  password_wo         = ephemeral.random_password.db_password.result
-  password_wo_version = 1  # Increment to trigger password rotation
-
-  skip_final_snapshot = true
-}
-
-# Secrets Manager with write-only
-resource "aws_secretsmanager_secret_version" "db_password" {
-  secret_id = aws_secretsmanager_secret.db_password.id
-
-  # Write-only secret string
-  secret_string_wo         = ephemeral.random_password.db_password.result
-  secret_string_wo_version = 1
-}
-```
-
-### Enhanced Variable Validations (Terraform 1.9+)
-
-Validation conditions can now reference other variables, data sources, and local values.
-
-```hcl
-# Reference data sources in validation
-data "aws_ec2_instance_type_offerings" "available" {
-  filter {
-    name   = "location"
-    values = [var.availability_zone]
-  }
-}
-
-variable "instance_type" {
-  type        = string
-  description = "EC2 instance type"
-
-  validation {
-    # NEW: Can reference data sources
-    condition = contains(
-      data.aws_ec2_instance_type_offerings.available.instance_types,
-      var.instance_type
-    )
-    error_message = "Instance type ${var.instance_type} is not available in the selected AZ."
-  }
-}
-
-# Cross-variable validation
-variable "min_instances" {
-  type    = number
-  default = 1
-}
-
-variable "max_instances" {
-  type    = number
-  default = 10
-
-  validation {
-    # NEW: Can reference other variables
-    condition     = var.max_instances >= var.min_instances
-    error_message = "max_instances must be >= min_instances"
-  }
-}
-```
-
-### S3 Native State Locking (Terraform 1.11+)
-
-S3 now supports native state locking without DynamoDB.
-
-```hcl
-terraform {
-  backend "s3" {
-    bucket       = "my-terraform-state"
-    key          = "project/terraform.tfstate"
-    region       = "us-east-1"
-    encrypt      = true
-
-    # NEW: S3-native locking (Terraform 1.11+)
-    use_lockfile = true
-
-    # DEPRECATED: DynamoDB locking (still works but no longer required)
-    # dynamodb_table = "terraform-locks"
-  }
-}
-```
-
-### Import Blocks (Terraform 1.5+)
-
-Declarative resource imports without command-line operations.
-
-```hcl
-# Import existing resources declaratively
-import {
-  to = aws_instance.web
-  id = "i-1234567890abcdef0"
-}
-
-resource "aws_instance" "web" {
-  ami           = "ami-0c55b159cbfafe1f0"
-  instance_type = "t3.micro"
-  # ... configuration must match existing resource
-}
-
-# Import with for_each
-import {
-  for_each = var.existing_bucket_names
-  to       = aws_s3_bucket.imported[each.key]
-  id       = each.value
-}
-```
-
-### Moved and Removed Blocks
-
-Safely refactor resources without destroying them.
-
-```hcl
-# Rename a resource
-moved {
-  from = aws_instance.old_name
-  to   = aws_instance.new_name
-}
-
-# Move to a module
-moved {
-  from = aws_vpc.main
-  to   = module.networking.aws_vpc.main
-}
-
-# Cross-type refactoring (1.8+)
-moved {
-  from = null_resource.example
-  to   = terraform_data.example
-}
-
-# Remove resource from state without destroying (1.7+)
-removed {
-  from = aws_instance.legacy
-
-  lifecycle {
-    destroy = false  # Keep the actual resource, just remove from state
-  }
-}
-```
-
-### Import Blocks with for_each (Terraform 1.12+)
-
-Import multiple resources using `for_each` meta-argument.
-
-```hcl
-# Import multiple S3 buckets using a map
-locals {
-  buckets = {
-    "staging" = "bucket1"
-    "uat"     = "bucket2"
-    "prod"    = "bucket3"
-  }
-}
-
-import {
-  for_each = local.buckets
-  to       = aws_s3_bucket.this[each.key]
-  id       = each.value
-}
-
-resource "aws_s3_bucket" "this" {
-  for_each = local.buckets
-}
-
-# Import across module instances using list of objects
-locals {
-  module_buckets = [
-    { group = "one", key = "bucket1", id = "one_1" },
-    { group = "one", key = "bucket2", id = "one_2" },
-    { group = "two", key = "bucket1", id = "two_1" },
-  ]
-}
-
-import {
-  for_each = local.module_buckets
-  id       = each.value.id
-  to       = module.group[each.value.group].aws_s3_bucket.this[each.value.key]
-}
-```
-
-### Actions Block (Terraform 1.14+)
-
-Actions enable provider-defined operations outside the standard CRUD model. Use for operations like Lambda invocations, cache invalidations, or database backups.
-
-```hcl
-# Invoke a Lambda function (example syntax)
-action "aws_lambda_invoke" "process_data" {
-  function_name = aws_lambda_function.processor.function_name
-  payload       = jsonencode({ action = "process" })
-}
-
-# Create CloudFront invalidation
-action "aws_cloudfront_create_invalidation" "invalidate_cache" {
-  distribution_id = aws_cloudfront_distribution.main.id
-  paths           = ["/*"]
-}
-
-# Actions support for_each
-action "aws_lambda_invoke" "batch_process" {
-  for_each = toset(["task1", "task2", "task3"])
-
-  function_name = aws_lambda_function.processor.function_name
-  payload       = jsonencode({ task = each.value })
-}
-```
-
-**Triggering Actions via Lifecycle:**
-
-Use `action_trigger` within a resource's lifecycle block to automatically invoke actions:
-
-```hcl
-resource "aws_lambda_function" "example" {
-  function_name = "my-function"
-  # ... other config ...
-
-  lifecycle {
-    action_trigger {
-      events  = [after_create, after_update]
-      actions = [action.aws_lambda_invoke.process_data]
-    }
-  }
-}
-
-action "aws_lambda_invoke" "process_data" {
-  function_name = aws_lambda_function.example.function_name
-  payload       = jsonencode({ action = "initialize" })
-}
-```
-
-**Manual Invocation:**
-
-Actions can also be invoked manually via CLI:
-
-```bash
-terraform apply -invoke action.aws_lambda_invoke.process_data
-```
-
-### List Resources and Query Command (Terraform 1.14+)
-
-Query and filter existing infrastructure using `.tfquery.hcl` files and the `terraform query` command.
-
-```hcl
-# my-resources.tfquery.hcl
-# Define list resources to query existing infrastructure
-
-list "aws_instance" "web_servers" {
-  filter {
-    name   = "tag:Environment"
-    values = [var.environment]
-  }
-
-  include_resource = true  # Include full resource details
-}
-
-list "aws_s3_bucket" "data_buckets" {
-  filter {
-    name   = "tag:Purpose"
-    values = ["data-storage"]
-  }
-}
-```
-
-```bash
-# Query infrastructure and output results
-terraform query
-
-# Generate import configuration from query results
-terraform query -generate-config-out="import_config.tf"
-
-# Output in JSON format
-terraform query -json
-
-# Use with variables
-terraform query -var 'environment=prod'
-```
-
-### Preconditions and Postconditions (Terraform 1.5+)
-
-Add custom validation within resource lifecycle.
-
-```hcl
-resource "aws_instance" "example" {
-  instance_type = "t3.micro"
-  ami           = data.aws_ami.example.id
-
-  lifecycle {
-    # Check before creation
-    precondition {
-      condition     = data.aws_ami.example.architecture == "x86_64"
-      error_message = "The selected AMI must be for the x86_64 architecture."
-    }
-
-    # Verify after creation
-    postcondition {
-      condition     = self.public_dns != ""
-      error_message = "EC2 instance must be in a VPC that has public DNS hostnames enabled."
-    }
-  }
-}
-
-# Preconditions on outputs
-output "web_url" {
-  value = "https://${aws_instance.web.public_dns}"
-
-  precondition {
-    condition     = aws_instance.web.public_dns != ""
-    error_message = "Instance must have a public DNS name."
-  }
-}
-```
+- **Provider versions:** pin majors with `~>` (e.g. `~> 6.0` for AWS, `~> 4.0` for AzureRM, `~> 7.0` for Google). Do not claim "latest" without verifying online during the current run. Keep cross-provider language consistent across SKILL.md, `references/terraform_best_practices.md`, and `assets/minimal-project/versions.tf`.
+- **Module versions:** always pin; review compatibility; test updates in non-production first.
 
 ## Resources
 
 ### references/
 
-The `references/` directory contains detailed documentation for reference:
+- `terraform_best_practices.md` — baseline patterns and required output shape
+- `provider_examples.md` — AWS / Azure / GCP / Kubernetes example configs
+- `common_patterns.md` — multi-env, workspace, composition, DR, conditional patterns
+- `modern_features.md` — Terraform 1.8+ feature reference + version decision table
 
-- `terraform_best_practices.md` - Comprehensive best practices guide
-- `common_patterns.md` - Common Terraform patterns and examples
-- `provider_examples.md` - Example configurations for popular providers
+Open directly:
 
-Open a reference directly by relative path:
 ```
-devops-skills-plugin/skills/terraform-generator/references/[filename].md
+devops-skills-plugin/skills/terraform-generator/references/<filename>.md
 ```
 
 ### assets/
 
-The `assets/` directory contains template files:
-
-- `minimal-project/` - Minimal Terraform project template
-
-Templates can be copied and customized for the user's specific needs.
+- `minimal-project/` — minimal Terraform project template; copy and customize.
 
 ## Notes
 
-- Always run devops-skills:terraform-validator after generation
-- For feature/version drift checks in CI, run `bash scripts/run_ci_checks.sh`
-- Web search is essential for custom providers/modules
-- Follow the principle of least surprise in configurations
-- Make configurations readable and maintainable
-- Include helpful comments and documentation
-- Generate realistic examples in terraform.tfvars when helpful
+- Always invoke `Skill(devops-skills:terraform-validator)` after generation.
+- For feature/version drift checks in CI, run `bash scripts/run_ci_checks.sh` (requires `terraform` for the fmt step; honors `STRICT_SHELLCHECK=true` to require shellcheck).
+- WebSearch / Context7 is essential for custom providers/modules.
+- Favor readability and least surprise; comment only where the WHY is non-obvious.
+- Generate realistic example values in `terraform.tfvars` when helpful.

--- a/devops-skills-plugin/skills/terraform-generator/references/common_patterns.md
+++ b/devops-skills-plugin/skills/terraform-generator/references/common_patterns.md
@@ -1,5 +1,20 @@
 # Common Terraform Patterns
 
+## Contents
+
+- [Multi-Environment Pattern](#multi-environment-pattern)
+- [Workspace Pattern](#workspace-pattern)
+- [Blue-Green Deployment Pattern](#blue-green-deployment-pattern)
+- [Data Layer Separation Pattern](#data-layer-separation-pattern)
+- [Module Composition Pattern](#module-composition-pattern)
+- [Conditional Resource Creation Pattern](#conditional-resource-creation-pattern)
+- [Service Mesh Pattern](#service-mesh-pattern)
+- [Tagging Strategy Pattern](#tagging-strategy-pattern)
+- [Secret Injection Pattern](#secret-injection-pattern)
+- [Auto-Scaling Pattern](#auto-scaling-pattern)
+- [Disaster Recovery Pattern](#disaster-recovery-pattern)
+- [Cost Optimization Pattern](#cost-optimization-pattern)
+
 ## Multi-Environment Pattern
 
 ### Directory Structure

--- a/devops-skills-plugin/skills/terraform-generator/references/modern_features.md
+++ b/devops-skills-plugin/skills/terraform-generator/references/modern_features.md
@@ -1,0 +1,473 @@
+# Modern Terraform Features and Version Decisions
+
+Version-gating tables and feature reference for Terraform 1.4+ through 1.14+. SKILL.md links here when generated output uses any feature listed below.
+
+## Contents
+
+- [Required Version Decision Table](#required-version-decision-table)
+- [Feature-Gating Examples](#feature-gating-examples)
+- [Terraform Version Feature Matrix](#terraform-version-feature-matrix)
+- [Provider-Defined Functions (Terraform 1.8+)](#provider-defined-functions-terraform-18)
+- [Ephemeral Resources (Terraform 1.10+)](#ephemeral-resources-terraform-110)
+- [Write-Only Arguments (Terraform 1.11+)](#write-only-arguments-terraform-111)
+- [Enhanced Variable Validations (Terraform 1.9+)](#enhanced-variable-validations-terraform-19)
+- [S3 Native State Locking (Terraform 1.11+)](#s3-native-state-locking-terraform-111)
+- [Import Blocks (Terraform 1.5+)](#import-blocks-terraform-15)
+- [Moved and Removed Blocks](#moved-and-removed-blocks)
+- [Import Blocks with for_each (Terraform 1.12+)](#import-blocks-with-for_each-terraform-112)
+- [Actions Block (Terraform 1.14+)](#actions-block-terraform-114)
+- [List Resources and Query Command (Terraform 1.14+)](#list-resources-and-query-command-terraform-114)
+- [Preconditions and Postconditions (Terraform 1.5+)](#preconditions-and-postconditions-terraform-15)
+
+## Required Version Decision Table
+
+| Generated Output Contains | Required Version to Emit |
+|---------------------------|--------------------------|
+| Any write-only argument (`*_wo`) | `>= 1.11, < 2.0` |
+| Ephemeral constructs only (no write-only) | `>= 1.10, < 2.0` |
+| Neither write-only nor ephemeral | Project baseline (default `>= 1.8, < 2.0`) |
+
+## Feature-Gating Examples
+
+```hcl
+# Positive: write-only usage requires Terraform 1.11+
+terraform {
+  required_version = ">= 1.11, < 2.0"
+}
+
+ephemeral "random_password" "db_password" {
+  length = 16
+}
+
+resource "aws_db_instance" "main" {
+  identifier          = "mydb"
+  instance_class      = "db.t3.micro"
+  allocated_storage   = 20
+  engine              = "postgres"
+  username            = "admin"
+  skip_final_snapshot = true
+
+  password_wo         = ephemeral.random_password.db_password.result
+  password_wo_version = 1
+}
+```
+
+```hcl
+# Negative: reject this pattern (write-only with Terraform 1.10)
+terraform {
+  required_version = ">= 1.10, < 2.0"
+}
+
+resource "aws_db_instance" "invalid" {
+  password_wo = "do-not-generate-this"
+}
+```
+
+## Terraform Version Feature Matrix
+
+| Feature | Minimum Version |
+|---------|-----------------|
+| `terraform_data` resource | 1.4+ |
+| `import {}` blocks | 1.5+ |
+| `check {}` blocks | 1.5+ |
+| Native testing (`.tftest.hcl`) | 1.6+ |
+| Test mocking | 1.7+ |
+| `removed {}` blocks | 1.7+ |
+| Provider-defined functions | 1.8+ |
+| Cross-type refactoring | 1.8+ |
+| Enhanced variable validations | 1.9+ |
+| `templatestring` function | 1.9+ |
+| Ephemeral resources | 1.10+ |
+| Write-only arguments | 1.11+ |
+| S3 native state locking | 1.11+ |
+| Import blocks with `for_each` | 1.12+ |
+| Actions block | 1.14+ |
+| List resources (`tfquery.hcl`) | 1.14+ |
+| `terraform query` command | 1.14+ |
+
+## Provider-Defined Functions (Terraform 1.8+)
+
+Provider-defined functions extend Terraform's built-in functions with provider-specific logic.
+
+**Syntax:** `provider::<provider_name>::<function_name>(arguments)`
+
+```hcl
+# AWS Provider Functions (v5.40+)
+locals {
+  # Parse an ARN into components
+  parsed_arn = provider::aws::arn_parse(aws_instance.web.arn)
+  account_id = local.parsed_arn.account
+  region     = local.parsed_arn.region
+
+  # Build an ARN from components
+  custom_arn = provider::aws::arn_build({
+    partition = "aws"
+    service   = "s3"
+    region    = ""
+    account   = ""
+    resource  = "my-bucket/my-key"
+  })
+}
+
+# Google Cloud Provider Functions (v5.23+)
+locals {
+  # Extract region from zone
+  region = provider::google::region_from_zone(var.zone)  # "us-west1-a" -> "us-west1"
+}
+
+# Kubernetes Provider Functions (v2.28+)
+locals {
+  # Encode HCL to Kubernetes manifest YAML
+  manifest_yaml = provider::kubernetes::manifest_encode(local.deployment_config)
+}
+```
+
+## Ephemeral Resources (Terraform 1.10+)
+
+Ephemeral resources provide temporary values that are never persisted in state or plan files. Critical for handling secrets securely.
+
+```hcl
+# Generate a password that never touches state
+ephemeral "random_password" "db_password" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+# Fetch secrets ephemerally from AWS Secrets Manager
+ephemeral "aws_secretsmanager_secret_version" "api_key" {
+  secret_id = aws_secretsmanager_secret.api_key.id
+}
+
+# Ephemeral variables (declare with ephemeral = true)
+variable "temporary_token" {
+  type      = string
+  ephemeral = true  # Value won't be stored in state
+}
+
+# Ephemeral outputs
+output "session_token" {
+  value     = ephemeral.aws_secretsmanager_secret_version.api_key.secret_string
+  ephemeral = true  # Won't be stored in state
+}
+```
+
+## Write-Only Arguments (Terraform 1.11+)
+
+Write-only arguments accept ephemeral values and are never persisted. They use `_wo` suffix and require a version attribute.
+
+```hcl
+terraform {
+  required_version = ">= 1.11, < 2.0"
+}
+
+# Secure database password handling
+ephemeral "random_password" "db_password" {
+  length = 16
+}
+
+resource "aws_db_instance" "main" {
+  identifier        = "mydb"
+  instance_class    = "db.t3.micro"
+  allocated_storage = 20
+  engine            = "postgres"
+  username          = "admin"
+
+  password_wo         = ephemeral.random_password.db_password.result
+  password_wo_version = 1  # MUST increment to trigger password rotation
+
+  skip_final_snapshot = true
+}
+
+# Secrets Manager with write-only
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = aws_secretsmanager_secret.db_password.id
+
+  secret_string_wo         = ephemeral.random_password.db_password.result
+  secret_string_wo_version = 1
+}
+```
+
+## Enhanced Variable Validations (Terraform 1.9+)
+
+Validation conditions can now reference other variables, data sources, and local values.
+
+```hcl
+# Reference data sources in validation
+data "aws_ec2_instance_type_offerings" "available" {
+  filter {
+    name   = "location"
+    values = [var.availability_zone]
+  }
+}
+
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type"
+
+  validation {
+    condition = contains(
+      data.aws_ec2_instance_type_offerings.available.instance_types,
+      var.instance_type
+    )
+    error_message = "Instance type ${var.instance_type} is not available in the selected AZ."
+  }
+}
+
+# Cross-variable validation
+variable "min_instances" {
+  type    = number
+  default = 1
+}
+
+variable "max_instances" {
+  type    = number
+  default = 10
+
+  validation {
+    condition     = var.max_instances >= var.min_instances
+    error_message = "max_instances must be >= min_instances"
+  }
+}
+```
+
+## S3 Native State Locking (Terraform 1.11+)
+
+S3 supports native state locking without DynamoDB.
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket       = "my-terraform-state"
+    key          = "project/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+
+    use_lockfile = true
+
+    # DEPRECATED: DynamoDB locking (still works but no longer required)
+    # dynamodb_table = "terraform-locks"
+  }
+}
+```
+
+## Import Blocks (Terraform 1.5+)
+
+Declarative resource imports without command-line operations.
+
+```hcl
+import {
+  to = aws_instance.web
+  id = "i-1234567890abcdef0"
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "t3.micro"
+  # ... configuration must match existing resource
+}
+
+import {
+  for_each = var.existing_bucket_names
+  to       = aws_s3_bucket.imported[each.key]
+  id       = each.value
+}
+```
+
+## Moved and Removed Blocks
+
+Safely refactor resources without destroying them.
+
+```hcl
+# Rename a resource
+moved {
+  from = aws_instance.old_name
+  to   = aws_instance.new_name
+}
+
+# Move to a module
+moved {
+  from = aws_vpc.main
+  to   = module.networking.aws_vpc.main
+}
+
+# Cross-type refactoring (1.8+)
+moved {
+  from = null_resource.example
+  to   = terraform_data.example
+}
+
+# Remove resource from state without destroying (1.7+)
+removed {
+  from = aws_instance.legacy
+
+  lifecycle {
+    destroy = false  # Keep the actual resource, just remove from state
+  }
+}
+```
+
+## Import Blocks with for_each (Terraform 1.12+)
+
+Import multiple resources using `for_each` meta-argument.
+
+```hcl
+# Import multiple S3 buckets using a map
+locals {
+  buckets = {
+    "staging" = "bucket1"
+    "uat"     = "bucket2"
+    "prod"    = "bucket3"
+  }
+}
+
+import {
+  for_each = local.buckets
+  to       = aws_s3_bucket.this[each.key]
+  id       = each.value
+}
+
+resource "aws_s3_bucket" "this" {
+  for_each = local.buckets
+}
+
+# Import across module instances using list of objects
+locals {
+  module_buckets = [
+    { group = "one", key = "bucket1", id = "one_1" },
+    { group = "one", key = "bucket2", id = "one_2" },
+    { group = "two", key = "bucket1", id = "two_1" },
+  ]
+}
+
+import {
+  for_each = local.module_buckets
+  id       = each.value.id
+  to       = module.group[each.value.group].aws_s3_bucket.this[each.value.key]
+}
+```
+
+## Actions Block (Terraform 1.14+)
+
+Actions enable provider-defined operations outside the standard CRUD model. Use for operations like Lambda invocations, cache invalidations, or database backups.
+
+```hcl
+# Invoke a Lambda function (example syntax)
+action "aws_lambda_invoke" "process_data" {
+  function_name = aws_lambda_function.processor.function_name
+  payload       = jsonencode({ action = "process" })
+}
+
+# Create CloudFront invalidation
+action "aws_cloudfront_create_invalidation" "invalidate_cache" {
+  distribution_id = aws_cloudfront_distribution.main.id
+  paths           = ["/*"]
+}
+
+# Actions support for_each
+action "aws_lambda_invoke" "batch_process" {
+  for_each = toset(["task1", "task2", "task3"])
+
+  function_name = aws_lambda_function.processor.function_name
+  payload       = jsonencode({ task = each.value })
+}
+```
+
+**Triggering Actions via Lifecycle:**
+
+Use `action_trigger` within a resource's lifecycle block to automatically invoke actions:
+
+```hcl
+resource "aws_lambda_function" "example" {
+  function_name = "my-function"
+  # ... other config ...
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create, after_update]
+      actions = [action.aws_lambda_invoke.process_data]
+    }
+  }
+}
+
+action "aws_lambda_invoke" "process_data" {
+  function_name = aws_lambda_function.example.function_name
+  payload       = jsonencode({ action = "initialize" })
+}
+```
+
+**Manual Invocation:**
+
+```bash
+terraform apply -invoke action.aws_lambda_invoke.process_data
+```
+
+## List Resources and Query Command (Terraform 1.14+)
+
+Query and filter existing infrastructure using `.tfquery.hcl` files and the `terraform query` command.
+
+```hcl
+# my-resources.tfquery.hcl
+list "aws_instance" "web_servers" {
+  filter {
+    name   = "tag:Environment"
+    values = [var.environment]
+  }
+
+  include_resource = true
+}
+
+list "aws_s3_bucket" "data_buckets" {
+  filter {
+    name   = "tag:Purpose"
+    values = ["data-storage"]
+  }
+}
+```
+
+```bash
+# Query infrastructure and output results
+terraform query
+
+# Generate import configuration from query results
+terraform query -generate-config-out="import_config.tf"
+
+# Output in JSON format
+terraform query -json
+
+# Use with variables
+terraform query -var 'environment=prod'
+```
+
+## Preconditions and Postconditions (Terraform 1.5+)
+
+Add custom validation within resource lifecycle.
+
+```hcl
+resource "aws_instance" "example" {
+  instance_type = "t3.micro"
+  ami           = data.aws_ami.example.id
+
+  lifecycle {
+    precondition {
+      condition     = data.aws_ami.example.architecture == "x86_64"
+      error_message = "The selected AMI must be for the x86_64 architecture."
+    }
+
+    postcondition {
+      condition     = self.public_dns != ""
+      error_message = "EC2 instance must be in a VPC that has public DNS hostnames enabled."
+    }
+  }
+}
+
+# Preconditions on outputs
+output "web_url" {
+  value = "https://${aws_instance.web.public_dns}"
+
+  precondition {
+    condition     = aws_instance.web.public_dns != ""
+    error_message = "Instance must have a public DNS name."
+  }
+}
+```

--- a/devops-skills-plugin/skills/terraform-generator/references/provider_examples.md
+++ b/devops-skills-plugin/skills/terraform-generator/references/provider_examples.md
@@ -1,5 +1,13 @@
 # Terraform Provider Examples
 
+## Contents
+
+- [AWS Provider](#aws-provider)
+- [Azure Provider](#azure-provider)
+- [Google Cloud Provider](#google-cloud-provider)
+- [Kubernetes Provider](#kubernetes-provider)
+- [Version snapshot (verify before use)](#version-snapshot-verify-before-use)
+
 ## AWS Provider
 
 ### Provider Configuration
@@ -9,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"  # Latest: v6.23.0 (Dec 2025)
+      version = "~> 6.0"  # see "Version snapshot" at the bottom of this file
     }
   }
 }
@@ -932,3 +940,14 @@ resource "kubernetes_horizontal_pod_autoscaler_v2" "app" {
   }
 }
 ```
+
+## Version snapshot (verify before use)
+
+Time-sensitive provider versions captured during the last review of this file. Always verify against the Terraform Registry before relying on a specific minor/patch.
+
+| Provider | Snapshot |
+|----------|----------|
+| `hashicorp/aws` | `~> 6.0`; latest observed v6.23.0 (Dec 2025) — confirm at https://registry.terraform.io/providers/hashicorp/aws |
+| `hashicorp/azurerm` | `~> 4.0` — confirm at https://registry.terraform.io/providers/hashicorp/azurerm |
+| `hashicorp/google` | `~> 7.0` — confirm at https://registry.terraform.io/providers/hashicorp/google |
+| `hashicorp/kubernetes` | major/minor pin matched to the target cluster — confirm at https://registry.terraform.io/providers/hashicorp/kubernetes |

--- a/devops-skills-plugin/skills/terraform-generator/references/terraform_best_practices.md
+++ b/devops-skills-plugin/skills/terraform-generator/references/terraform_best_practices.md
@@ -1,5 +1,24 @@
 # Terraform Best Practices
 
+## Contents
+
+- [Project Structure](#project-structure)
+- [Naming Conventions](#naming-conventions)
+- [Version Pinning](#version-pinning)
+- [State Management](#state-management)
+- [Variable Management](#variable-management)
+- [Resource Management](#resource-management)
+- [Data Sources](#data-sources)
+- [Local Values](#local-values)
+- [Dynamic Blocks](#dynamic-blocks)
+- [Count and For_Each](#count-and-for_each)
+- [Module Best Practices](#module-best-practices)
+- [Security Best Practices](#security-best-practices)
+- [Testing and Validation](#testing-and-validation)
+- [Documentation](#documentation)
+- [Performance Optimization](#performance-optimization)
+- [Common Pitfalls to Avoid](#common-pitfalls-to-avoid)
+
 ## Project Structure
 
 ### Standard Project Layout


### PR DESCRIPTION
- Rewrite frontmatter descriptions with use when + trigger phrases
- Move duplicated reference content out of SKILL.md (terraform −626, promql −914)
- Add helm-generator --dry-run mode; fix 2 unpinned action SHAs in github-actions
- De-shout, normalize Context7 MCP names, add TOCs to long references
- Add YAML-safety + consistency-check pre-flight rules to plan