### PR TITLE
Add CODEOWNERS for skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/devops-skills-plugin/skills/ @akin-ozer


### PR DESCRIPTION
## Summary
- Add .github/CODEOWNERS assigning devops-skills-plugin/skills/ to @akin-ozer

## Validation
- Verified diff is limited to .github/CODEOWNERS
- No build/test suite run; metadata-only CODEOWNERS change