### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @akin-ozer


### PR DESCRIPTION
Adds .github/CODEOWNERS with @akin-ozer as owner for the whole repository.